### PR TITLE
fix: gameplay interactions, portals and elytra handling

### DIFF
--- a/.github/workflows/port-agriculture-temp.yml
+++ b/.github/workflows/port-agriculture-temp.yml
@@ -1,0 +1,407 @@
+name: Port Pumpkin crop parity
+
+on:
+  push:
+    branches: [fix/gameplay-interactions-2026-08-24]
+    paths:
+      - '.github/workflows/port-agriculture-temp.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  port:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: fix/gameplay-interactions-2026-08-24
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.x'
+      - name: Apply Pumpkin crop parity port
+        shell: bash
+        run: |
+          python3 <<'PY'
+          from pathlib import Path
+          import re
+
+          world = Path('core/world/world.go')
+          text = world.read_text()
+          pattern = re.compile(r'// TickCrops advances.*?\nfunc \(w \*World\) TickCrops\(tick int64, maxChanges int\) \[\]BlockChange \{.*?\n\}\n\n(?=// TickFarmland applies)', re.S)
+          replacement = '''// TickCrops advances loaded crops using Pumpkin/vanilla-style crop rules.\n// The detailed implementation lives in crop_growth.go so Java and Bedrock\n// share one canonical growth simulation.\nfunc (w *World) TickCrops(tick int64, maxChanges int) []BlockChange {\n\treturn w.tickCropsPumpkin(tick, maxChanges)\n}\n\n'''
+          text, n = pattern.subn(replacement, text, count=1)
+          if n != 1:
+              raise SystemExit(f'failed to replace TickCrops: {n}')
+          world.write_text(text)
+
+          Path('core/world/crop_growth.go').write_text(r'''package world
+
+import (
+    "math"
+    "strconv"
+)
+
+// tickCropsPumpkin ports Pumpkin's shared CropBlockBase growth model into the
+// canonical GoCraft world. SetBlock drives the protocol-neutral block observer,
+// so every stage and generated gourd is mirrored to Java and Bedrock clients.
+func (w *World) tickCropsPumpkin(tick int64, maxChanges int) []BlockChange {
+    if maxChanges <= 0 {
+        return nil
+    }
+    w.mu.RLock()
+    chunks := make([]*Chunk, 0, len(w.chunks))
+    for _, chunk := range w.chunks {
+        chunks = append(chunks, chunk)
+    }
+    w.mu.RUnlock()
+
+    changes := make([]BlockChange, 0, maxChanges)
+    for _, chunk := range chunks {
+        for sectionIndex, section := range chunk.Sections {
+            if section == nil || section.NonAir == 0 {
+                continue
+            }
+            palette := section.BlockPalette()
+            hasCrop := false
+            for _, block := range palette {
+                if _, ok := pumpkinCropMaximumAge(block.ResourceLocation()); ok {
+                    hasCrop = true
+                    break
+                }
+            }
+            if !hasCrop {
+                continue
+            }
+            for index, paletteIndex := range section.BlockData() {
+                if int(paletteIndex) >= len(palette) {
+                    continue
+                }
+                block := palette[paletteIndex]
+                name := block.ResourceLocation()
+                maxAge, ok := pumpkinCropMaximumAge(name)
+                if !ok {
+                    continue
+                }
+                age, err := strconv.Atoi(block.Properties["age"])
+                if err != nil {
+                    continue
+                }
+                localX := index % SectionSize
+                localZ := (index / SectionSize) % SectionSize
+                localY := index / (SectionSize * SectionSize)
+                x := int(chunk.X)*SectionSize + localX
+                y := SectionMinY(sectionIndex) + localY
+                z := int(chunk.Z)*SectionSize + localZ
+                roll := cropGrowthHash(x, y, z, tick)
+
+                switch name {
+                case "minecraft:nether_wart":
+                    // Pumpkin: one growth attempt in ten random ticks.
+                    if age >= maxAge || roll%10 != 0 {
+                        continue
+                    }
+                    changes = append(changes, cropAgeChange(x, y, z, block, age+1))
+
+                case "minecraft:sweet_berry_bush":
+                    // Pumpkin gives berry bushes an outer 1/5 gate, then grows
+                    // exactly one stage if the block above does not obstruct it.
+                    if age >= maxAge || roll%5 != 0 || IsSolidLandingSurface(w.GetBlock(x, y+1, z).ResourceLocation()) {
+                        continue
+                    }
+                    changes = append(changes, cropAgeChange(x, y, z, block, age+1))
+
+                case "minecraft:cocoa":
+                    // Cocoa is not CropBlockBase in Pumpkin; retain GoCraft's
+                    // existing bounded cadence while preserving its 0..2 stages.
+                    if age >= maxAge || roll%5 != 0 {
+                        continue
+                    }
+                    changes = append(changes, cropAgeChange(x, y, z, block, age+1))
+
+                default:
+                    // Beetroot only delegates one out of three random ticks to
+                    // CropBlockBase in Pumpkin.
+                    if name == "minecraft:beetroots" {
+                        if roll%3 != 0 {
+                            continue
+                        }
+                        roll = mixCropHash(roll)
+                    }
+                    moisture := w.cropAvailableMoisture(x, y, z, name)
+                    denominator := uint64(math.Floor(25.0/float64(moisture))) + 1
+                    if denominator == 0 || roll%denominator != 0 {
+                        continue
+                    }
+                    if age < maxAge {
+                        changes = append(changes, cropAgeChange(x, y, z, block, age+1))
+                        break
+                    }
+                    if name == "minecraft:pumpkin_stem" || name == "minecraft:melon_stem" {
+                        // A mature stem consumes two mutations atomically: the
+                        // fruit and the attached stem. Do not emit half a pair.
+                        if len(changes)+2 > maxChanges {
+                            continue
+                        }
+                        fruitChanges := w.growGourd(x, y, z, block, roll)
+                        changes = append(changes, fruitChanges...)
+                    }
+                }
+                if len(changes) >= maxChanges {
+                    break
+                }
+            }
+            if len(changes) >= maxChanges {
+                break
+            }
+        }
+        if len(changes) >= maxChanges {
+            break
+        }
+    }
+    if len(changes) > maxChanges {
+        changes = changes[:maxChanges]
+    }
+    for _, change := range changes {
+        w.SetBlock(change.X, change.Y, change.Z, change.Block)
+    }
+    return changes
+}
+
+func pumpkinCropMaximumAge(name string) (int, bool) {
+    switch name {
+    case "minecraft:wheat", "minecraft:carrots", "minecraft:potatoes",
+        "minecraft:melon_stem", "minecraft:pumpkin_stem":
+        return 7, true
+    case "minecraft:beetroots", "minecraft:nether_wart", "minecraft:sweet_berry_bush":
+        return 3, true
+    case "minecraft:cocoa":
+        return 2, true
+    case "minecraft:torchflower_crop":
+        return 1, true
+    case "minecraft:pitcher_crop":
+        return 4, true
+    default:
+        return 0, false
+    }
+}
+
+func cropAgeChange(x, y, z int, block Block, age int) BlockChange {
+    replacement := copyWorldBlock(block)
+    replacement.Properties["age"] = strconv.Itoa(age)
+    return BlockChange{X: x, Y: y, Z: z, Block: replacement}
+}
+
+// cropAvailableMoisture is a direct Go translation of Pumpkin's
+// get_available_moisture: center farmland counts fully, neighbouring farmland
+// counts at one quarter strength, hydrated farmland is worth 3 instead of 1,
+// and crowded/diagonal plant layouts halve the final growth factor.
+func (w *World) cropAvailableMoisture(x, y, z int, cropName string) float32 {
+    moisture := float32(1)
+    for dx := -1; dx <= 1; dx++ {
+        for dz := -1; dz <= 1; dz++ {
+            farmland := w.GetBlock(x+dx, y-1, z+dz)
+            local := float32(0)
+            if farmland.ResourceLocation() == "minecraft:farmland" {
+                local = 1
+                level, _ := strconv.Atoi(farmland.Properties["moisture"])
+                if level != 0 {
+                    local = 3
+                }
+            }
+            if dx != 0 || dz != 0 {
+                local /= 4
+            }
+            moisture += local
+        }
+    }
+
+    same := func(dx, dz int) bool {
+        return w.GetBlock(x+dx, y, z+dz).ResourceLocation() == cropName
+    }
+    horizontal := same(-1, 0) || same(1, 0)
+    vertical := same(0, -1) || same(0, 1)
+    if (horizontal && vertical) || same(-1, -1) || same(1, -1) || same(1, 1) || same(-1, 1) {
+        moisture /= 2
+    }
+    return moisture
+}
+
+func (w *World) growGourd(x, y, z int, stem Block, roll uint64) []BlockChange {
+    dirs := [...]struct {
+        dx, dz int
+        facing string
+    }{
+        {0, -1, "north"},
+        {0, 1, "south"},
+        {-1, 0, "west"},
+        {1, 0, "east"},
+    }
+    dir := dirs[int(mixCropHash(roll)%uint64(len(dirs)))]
+    fx, fz := x+dir.dx, z+dir.dz
+    if !w.GetBlock(fx, y, fz).IsAir() || !supportsGourdFruit(w.GetBlock(fx, y-1, fz).ResourceLocation()) {
+        return nil
+    }
+    fruit := "melon"
+    attached := "attached_melon_stem"
+    if stem.ResourceLocation() == "minecraft:pumpkin_stem" {
+        fruit = "pumpkin"
+        attached = "attached_pumpkin_stem"
+    }
+    return []BlockChange{
+        {X: fx, Y: y, Z: fz, Block: Block{Namespace: "minecraft", Name: fruit}},
+        {X: x, Y: y, Z: z, Block: Block{Namespace: "minecraft", Name: attached, Properties: map[string]string{"facing": dir.facing}}},
+    }
+}
+
+func supportsGourdFruit(name string) bool {
+    switch name {
+    case "minecraft:farmland", "minecraft:dirt", "minecraft:grass_block", "minecraft:coarse_dirt",
+        "minecraft:podzol", "minecraft:mycelium", "minecraft:rooted_dirt", "minecraft:mud",
+        "minecraft:muddy_mangrove_roots":
+        return true
+    default:
+        return false
+    }
+}
+
+func cropGrowthHash(x, y, z int, tick int64) uint64 {
+    h := uint64(int64(x))*0x9e3779b185ebca87 ^ uint64(int64(y))*0xc2b2ae3d27d4eb4f ^
+        uint64(int64(z))*0x165667b19e3779f9 ^ uint64(tick/20+1)*0x27d4eb2f165667c5
+    return mixCropHash(h)
+}
+
+func mixCropHash(h uint64) uint64 {
+    h ^= h >> 33
+    h *= 0xff51afd7ed558ccd
+    h ^= h >> 33
+    h *= 0xc4ceb9fe1a85ec53
+    h ^= h >> 33
+    return h
+}
+''')
+
+          java = Path('java/handler/block.go')
+          text = java.read_text()
+          old = '''\tcase target.ResourceLocation() == "minecraft:farmland" && held.ItemID == "minecraft:beetroot_seeds":\n\t\tcrop = coreworld.Block{Namespace: "minecraft", Name: "beetroots", Properties: map[string]string{"age": "0"}}\n\tcase target.ResourceLocation() == "minecraft:soul_sand" && held.ItemID == "minecraft:nether_wart":'''
+          new = '''\tcase target.ResourceLocation() == "minecraft:farmland" && held.ItemID == "minecraft:beetroot_seeds":\n\t\tcrop = coreworld.Block{Namespace: "minecraft", Name: "beetroots", Properties: map[string]string{"age": "0"}}\n\tcase target.ResourceLocation() == "minecraft:farmland" && held.ItemID == "minecraft:melon_seeds":\n\t\tcrop = coreworld.Block{Namespace: "minecraft", Name: "melon_stem", Properties: map[string]string{"age": "0"}}\n\tcase target.ResourceLocation() == "minecraft:farmland" && held.ItemID == "minecraft:pumpkin_seeds":\n\t\tcrop = coreworld.Block{Namespace: "minecraft", Name: "pumpkin_stem", Properties: map[string]string{"age": "0"}}\n\tcase target.ResourceLocation() == "minecraft:farmland" && held.ItemID == "minecraft:torchflower_seeds":\n\t\tcrop = coreworld.Block{Namespace: "minecraft", Name: "torchflower_crop", Properties: map[string]string{"age": "0"}}\n\tcase target.ResourceLocation() == "minecraft:soul_sand" && held.ItemID == "minecraft:nether_wart":'''
+          if old not in text:
+              raise SystemExit('java planting marker not found')
+          text = text.replace(old, new, 1)
+          text = text.replace('''\tcase "minecraft:wheat", "minecraft:carrots", "minecraft:potatoes":\n\t\tmaxAge = 7\n\tcase "minecraft:beetroots", "minecraft:nether_wart", "minecraft:sweet_berry_bush":''', '''\tcase "minecraft:wheat", "minecraft:carrots", "minecraft:potatoes", "minecraft:melon_stem", "minecraft:pumpkin_stem":\n\t\tmaxAge = 7\n\tcase "minecraft:beetroots", "minecraft:sweet_berry_bush":''', 1)
+          old_inc = '''\t\tincrease := 2 + rand.Intn(4) //nolint:gosec\n\t\tnewAge := age + increase'''
+          new_inc = '''\t\tincrease := 2 + rand.Intn(4) //nolint:gosec\n\t\tif target.ResourceLocation() == "minecraft:beetroots" {\n\t\t\t// Pumpkin's beetroot override divides the normal 2..5 increase by 3.\n\t\t\tincrease /= 3\n\t\t}\n\t\tnewAge := age + increase'''
+          if old_inc not in text:
+              raise SystemExit('java bone meal marker not found')
+          text = text.replace(old_inc, new_inc, 1)
+          java.write_text(text)
+
+          bedrock = Path('server/bedrock_actions.go')
+          text = bedrock.read_text()
+          old_bm = '''\tif item == "minecraft:bone_meal" {\n\t\tif maxAge, ok := bedrockCropMaxAge(name); ok {\n\t\t\tage, _ := strconv.Atoi(target.Properties["age"])\n\t\t\tif age < maxAge {\n\t\t\t\treplacement := bedrockCopyBlock(target)\n\t\t\t\treplacement.Properties["age"] = strconv.Itoa(maxAge)\n\t\t\t\ts.setBedrockActionBlock(x, y, z, replacement)\n\t\t\t\ts.consumeBedrockHeldItem(p, 1)\n\t\t\t\treturn true\n\t\t\t}\n\t\t}\n\t}'''
+          new_bm = '''\tif item == "minecraft:bone_meal" {\n\t\tif maxAge, ok := bedrockCropMaxAge(name); ok {\n\t\t\tage, _ := strconv.Atoi(target.Properties["age"])\n\t\t\tif age < maxAge {\n\t\t\t\tincrease := bedrockBoneMealIncrease(name, x, y, z, s.worldAge)\n\t\t\t\tnewAge := min(maxAge, age+increase)\n\t\t\t\tif newAge != age {\n\t\t\t\t\treplacement := bedrockCopyBlock(target)\n\t\t\t\t\treplacement.Properties["age"] = strconv.Itoa(newAge)\n\t\t\t\t\ts.setBedrockActionBlock(x, y, z, replacement)\n\t\t\t\t}\n\t\t\t\t// Pumpkin consumes the bone meal even when beetroot's divided\n\t\t\t\t// increase happens to round down to zero.\n\t\t\t\ts.consumeBedrockHeldItem(p, 1)\n\t\t\t\treturn true\n\t\t\t}\n\t\t}\n\t}'''
+          if old_bm not in text:
+              raise SystemExit('bedrock bone meal marker not found')
+          text = text.replace(old_bm, new_bm, 1)
+          helper_marker = '''func bedrockCropMaxAge(name string) (int, bool) {'''
+          helper = '''func bedrockBoneMealIncrease(name string, x, y, z int, worldAge int64) int {\n\th := uint64(int64(x))*0x9e3779b185ebca87 ^ uint64(int64(y))*0xc2b2ae3d27d4eb4f ^\n\t\tuint64(int64(z))*0x165667b19e3779f9 ^ uint64(worldAge+1)*0x27d4eb2f165667c5\n\th ^= h >> 33\n\th *= 0xff51afd7ed558ccd\n\th ^= h >> 33\n\tincrease := 2 + int(h%4)\n\tif name == "minecraft:beetroots" {\n\t\tincrease /= 3\n\t}\n\treturn increase\n}\n\n'''
+          if helper_marker not in text:
+              raise SystemExit('bedrock crop max marker not found')
+          text = text.replace(helper_marker, helper + helper_marker, 1)
+          bedrock.write_text(text)
+
+          Path('core/world/crop_pumpkin_test.go').write_text(r'''package world
+
+import "testing"
+
+func TestPumpkinCropMoistureAndCrowding(t *testing.T) {
+    w := New(&FlatGenerator{}, nil, false)
+    defer w.Close()
+    w.SetBlock(0, 40, 0, Block{Namespace: "minecraft", Name: "farmland", Properties: map[string]string{"moisture": "7"}})
+    w.SetBlock(0, 41, 0, Block{Namespace: "minecraft", Name: "wheat", Properties: map[string]string{"age": "0"}})
+    if got := w.cropAvailableMoisture(0, 41, 0, "minecraft:wheat"); got != 4 {
+        t.Fatalf("single hydrated farmland moisture = %v, want 4", got)
+    }
+    for dx := -1; dx <= 1; dx++ {
+        for dz := -1; dz <= 1; dz++ {
+            w.SetBlock(dx, 40, dz, Block{Namespace: "minecraft", Name: "farmland", Properties: map[string]string{"moisture": "7"}})
+        }
+    }
+    if got := w.cropAvailableMoisture(0, 41, 0, "minecraft:wheat"); got != 10 {
+        t.Fatalf("3x3 hydrated farmland moisture = %v, want 10", got)
+    }
+    w.SetBlock(1, 41, 0, Block{Namespace: "minecraft", Name: "wheat", Properties: map[string]string{"age": "0"}})
+    w.SetBlock(0, 41, 1, Block{Namespace: "minecraft", Name: "wheat", Properties: map[string]string{"age": "0"}})
+    if got := w.cropAvailableMoisture(0, 41, 0, "minecraft:wheat"); got != 5 {
+        t.Fatalf("crowded crop moisture = %v, want 5", got)
+    }
+}
+
+func TestMaturePumpkinStemCreatesFruitAndAttaches(t *testing.T) {
+    w := New(&FlatGenerator{}, nil, false)
+    defer w.Close()
+    w.SetBlock(0, 40, 0, Block{Namespace: "minecraft", Name: "farmland", Properties: map[string]string{"moisture": "7"}})
+    w.SetBlock(0, 41, 0, Block{Namespace: "minecraft", Name: "pumpkin_stem", Properties: map[string]string{"age": "7"}})
+    for _, p := range [][2]int{{0, -1}, {0, 1}, {-1, 0}, {1, 0}} {
+        w.SetBlock(p[0], 40, p[1], Block{Namespace: "minecraft", Name: "dirt"})
+        w.SetBlock(p[0], 41, p[1], Air)
+    }
+    for tick := int64(20); tick <= 4000; tick += 20 {
+        w.TickCrops(tick, 16)
+        stem := w.GetBlock(0, 41, 0)
+        if stem.ResourceLocation() != "minecraft:attached_pumpkin_stem" {
+            continue
+        }
+        fruit := 0
+        for _, p := range [][2]int{{0, -1}, {0, 1}, {-1, 0}, {1, 0}} {
+            if w.GetBlock(p[0], 41, p[1]).ResourceLocation() == "minecraft:pumpkin" {
+                fruit++
+            }
+        }
+        if fruit != 1 {
+            t.Fatalf("attached stem generated %d pumpkins, want 1", fruit)
+        }
+        return
+    }
+    t.Fatal("mature pumpkin stem never generated fruit")
+}
+
+func TestNetherWartUsesDedicatedStages(t *testing.T) {
+    if maxAge, ok := pumpkinCropMaximumAge("minecraft:nether_wart"); !ok || maxAge != 3 {
+        t.Fatalf("nether wart max age = %d, ok=%v; want 3,true", maxAge, ok)
+    }
+    if maxAge, ok := pumpkinCropMaximumAge("minecraft:pumpkin_stem"); !ok || maxAge != 7 {
+        t.Fatalf("pumpkin stem max age = %d, ok=%v; want 7,true", maxAge, ok)
+    }
+}
+''')
+
+          Path('server/crop_bonemeal_test.go').write_text(r'''package server
+
+import "testing"
+
+func TestBedrockBoneMealUsesPumpkinStageIncrease(t *testing.T) {
+    for rollAge := int64(0); rollAge < 32; rollAge++ {
+        got := bedrockBoneMealIncrease("minecraft:wheat", 3, 64, -7, rollAge)
+        if got < 2 || got > 5 {
+            t.Fatalf("wheat bone meal increase = %d, want 2..5", got)
+        }
+        beetroot := bedrockBoneMealIncrease("minecraft:beetroots", 3, 64, -7, rollAge)
+        if beetroot < 0 || beetroot > 1 {
+            t.Fatalf("beetroot bone meal increase = %d, want 0..1", beetroot)
+        }
+    }
+}
+''')
+          PY
+          gofmt -w core/world/world.go core/world/crop_growth.go core/world/crop_pumpkin_test.go java/handler/block.go server/bedrock_actions.go server/crop_bonemeal_test.go
+          go test ./...
+      - name: Commit port
+        shell: bash
+        run: |
+          rm .github/workflows/port-agriculture-temp.yml
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          git commit -m 'feat: port Pumpkin crop growth parity'
+          git push origin HEAD:fix/gameplay-interactions-2026-08-24

--- a/bedrock/remote_player_teleport_test.go
+++ b/bedrock/remote_player_teleport_test.go
@@ -1,0 +1,22 @@
+package bedrock
+
+import (
+	"testing"
+
+	"GoCraft/core/spatial"
+	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+)
+
+func TestBedrockRemotePlayerMoveMode(t *testing.T) {
+	origin := spatial.Vec3{X: 10, Y: 64, Z: 10}
+
+	if got := bedrockRemotePlayerMoveMode(origin, spatial.Vec3{X: 17.9, Y: 64, Z: 10}); got != byte(packet.MoveModeNormal) {
+		t.Fatalf("small movement should stay normal, got mode %d", got)
+	}
+	if got := bedrockRemotePlayerMoveMode(origin, spatial.Vec3{X: 18.1, Y: 64, Z: 10}); got != byte(packet.MoveModeTeleport) {
+		t.Fatalf("large horizontal jump should use teleport mode, got mode %d", got)
+	}
+	if got := bedrockRemotePlayerMoveMode(origin, spatial.Vec3{X: 10, Y: 72.1, Z: 10}); got != byte(packet.MoveModeTeleport) {
+		t.Fatalf("large vertical jump should use teleport mode, got mode %d", got)
+	}
+}

--- a/bedrock/sync.go
+++ b/bedrock/sync.go
@@ -303,7 +303,7 @@ func (l *Listener) syncPlayers(viewer *bedrockSession, players []*player.Player,
 				Pitch:           p.Rotation.Pitch,
 				Yaw:             p.Rotation.Yaw,
 				HeadYaw:         p.Rotation.Yaw,
-				Mode:            packet.MoveModeNormal,
+				Mode:            bedrockRemotePlayerMoveMode(previous.position, p.Position),
 				OnGround:        p.OnGround,
 				Tick:            tick,
 			})
@@ -356,6 +356,20 @@ func bedrockPlayerInView(viewer, target *player.Player) bool {
 	dz := chunkCoordinate(target.Position.Z) - chunkCoordinate(viewer.Position.Z)
 	return dx >= -bedrockChunkRadius && dx <= bedrockChunkRadius &&
 		dz >= -bedrockChunkRadius && dz <= bedrockChunkRadius
+}
+
+// bedrockRemotePlayerMoveMode keeps ordinary walking/sprinting smooth, but
+// marks teleport-sized canonical jumps explicitly. Bedrock clients may discard
+// a huge MoveModeNormal delta for a remote actor, leaving a Java player stale or
+// invisible after /tp until that actor is respawned.
+func bedrockRemotePlayerMoveMode(previous, current spatial.Vec3) byte {
+	const maxNormalDelta = 8.0
+	if math.Abs(current.X-previous.X) > maxNormalDelta ||
+		math.Abs(current.Y-previous.Y) > maxNormalDelta ||
+		math.Abs(current.Z-previous.Z) > maxNormalDelta {
+		return byte(packet.MoveModeTeleport)
+	}
+	return byte(packet.MoveModeNormal)
 }
 
 func entityInView(viewer *player.Player, entity *corentity.Entity) bool {

--- a/core/helper/NewChestManager.go
+++ b/core/helper/NewChestManager.go
@@ -1,83 +1,120 @@
 package helper
 
 import (
+	"errors"
+	"fmt"
+
 	"GoCraft/core/spatial"
 	coreworld "GoCraft/core/world"
-	"errors"
-	"fmt"
 )
 
-{
-	"errors"
-	"fmt"
-	"GoGraft/core/spatial"
-	coreworld "GoCraft/Core/world"
-}
 const (
-	SingleChestsSlots= 27
-	DoubleChestsSlots= 54
+	SingleChestSlots = 27
+	DoubleChestSlots = 54
+
+	// Backward-compatible names kept for callers of the first implementation.
+	SingleChestsSlots = SingleChestSlots
+	DoubleChestsSlots = DoubleChestSlots
 )
+
 type ChestManager struct {
 	World *coreworld.World
 }
+
 type ChestInfo struct {
 	Position spatial.BlockPos
-	Facing string
-	Type   string
-	Kind string
-
+	Facing   string
+	Type     string
+	Kind     string
 }
 
-func NewChestManager (W *coreworld.World) *ChestManager {
-	return &ChestManager{W}
+func NewChestManager(w *coreworld.World) *ChestManager {
+	return &ChestManager{World: w}
 }
 
-
-func ( m* ChestManager) PlaceChest(x, y, z int, facing string ) error {
-	if m == nil || m.World==nil {
-		return errors.New("chest manager has no world")
-	}
-	if !validFacing(facing) {
-		return fmt.Errorf("invalid chest facing %s", facing)
-	if !m.World.GetBlock(x,y,z).IsAir(){
-		return fmt.Errorf("chest facing %s is not air", facing)
-	}
-
-	chest := makeChestBlock("minecraft:chest", facing, "single")
-	m.World.SetBlock(x,y,z,chest)
-	}
+func (m *ChestManager) PlaceChest(x, y, z int, facing string) error {
+	return m.place(x, y, z, "minecraft:chest", facing)
+}
 
 func (m *ChestManager) PlaceTrappedChest(x, y, z int, facing string) error {
-	if m == nil || m.World==nil {
+	return m.place(x, y, z, "minecraft:trapped_chest", facing)
+}
+
+func (m *ChestManager) place(x, y, z int, kind, facing string) error {
+	if m == nil || m.World == nil {
 		return errors.New("chest manager has no world")
 	}
 	if !validFacing(facing) {
-		return fmt.Errorf("invalid chest facing %s", facing)
+		return fmt.Errorf("invalid chest facing %q", facing)
 	}
-	if !m.World.GetBlock(x,y,z).IsAir(){
-		return fmt.Errorf("chest facing %s is not air", facing)
+	if !m.World.GetBlock(x, y, z).IsAir() {
+		return fmt.Errorf("chest position %d %d %d is not air", x, y, z)
 	}
-	m.World.SetBlock(
-		x,y,z,
-		makeChestBlock("minecraft:chest", facing, "double"),
-	)
+	m.World.SetBlock(x, y, z, makeChestBlock(kind, facing, "single"))
 	return nil
 }
 
 func (m *ChestManager) RemoveChest(x, y, z int) error {
-	if m == nil || m.World==nil {
+	if m == nil || m.World == nil {
 		return errors.New("chest manager has no world")
 	}
-	block := m.World.GetBlock(x,y,z)
+	block := m.World.GetBlock(x, y, z)
 	if !isChestBlock(block) {
-		return fmt.Errorf("chest facing %s is not a chest", facing)
+		return fmt.Errorf("block at %d %d %d is not a chest", x, y, z)
 	}
-	m.World.SetBlock(x,y,z, coreworld.Air)
+	m.World.SetBlock(x, y, z, coreworld.Air)
 	return nil
+}
+
+func (m *ChestManager) ChestAt(x, y, z int) (ChestInfo, bool) {
+	if m == nil || m.World == nil {
+		return ChestInfo{}, false
 	}
-func (m *ChestManager ) ChestAt(x, y, z int ) ( ChestInfo, bool){
-	if m == nil || m.World==nil {
-		return  ChestInfo{}, false
+	block := m.World.GetBlock(x, y, z)
+	if !isChestBlock(block) {
+		return ChestInfo{}, false
+	}
+	return ChestInfo{
+		Position: spatial.BlockPos{X: int32(x), Y: int32(y), Z: int32(z)},
+		Facing:   block.Properties["facing"],
+		Type:     block.Properties["type"],
+		Kind:     block.ResourceLocation(),
+	}, true
+}
+
+func validFacing(facing string) bool {
+	switch facing {
+	case "north", "south", "east", "west":
+		return true
+	default:
+		return false
 	}
 }
+
+func makeChestBlock(kind, facing, chestType string) coreworld.Block {
+	namespace, name := "minecraft", kind
+	for i := 0; i < len(kind); i++ {
+		if kind[i] == ':' {
+			namespace, name = kind[:i], kind[i+1:]
+			break
+		}
+	}
+	return coreworld.Block{
+		Namespace: namespace,
+		Name:      name,
+		Properties: map[string]string{
+			"facing":      facing,
+			"type":        chestType,
+			"waterlogged": "false",
+		},
+	}
+}
+
+func isChestBlock(block coreworld.Block) bool {
+	switch block.ResourceLocation() {
+	case "minecraft:chest", "minecraft:trapped_chest":
+		return true
+	default:
+		return false
+	}
 }

--- a/core/world/portal.go
+++ b/core/world/portal.go
@@ -1,52 +1,93 @@
 package world
 
-// NetherPortalInterior returns the six portal-block changes needed to fill a
-// standard 4x5 obsidian frame containing the clicked obsidian block. Frames in
-// either horizontal axis are accepted and their four corner blocks are
-// optional, matching vanilla portal construction.
+const (
+	minNetherPortalInteriorWidth  = 2
+	maxNetherPortalInteriorWidth  = 21
+	minNetherPortalInteriorHeight = 3
+	maxNetherPortalInteriorHeight = 21
+)
+
+// NetherPortalInterior finds a valid vanilla-sized Nether portal frame that
+// contains the clicked obsidian block and returns all interior portal blocks.
+// Vanilla portals may have an interior from 2x3 up to 21x21 blocks, and their
+// four corner blocks are optional. Both X- and Z-oriented frames are accepted.
 func NetherPortalInterior(w *World, clickedX, clickedY, clickedZ int) ([]BlockChange, bool) {
 	if w == nil || w.GetBlock(clickedX, clickedY, clickedZ).ResourceLocation() != "minecraft:obsidian" {
 		return nil, false
 	}
+
 	for _, axis := range []string{"x", "z"} {
-		for horizontalOffset := -3; horizontalOffset <= 0; horizontalOffset++ {
-			for verticalOffset := -4; verticalOffset <= 0; verticalOffset++ {
-				baseX, bottom, baseZ := clickedX, clickedY+verticalOffset, clickedZ
-				if axis == "x" {
-					baseX += horizontalOffset
-				} else {
-					baseZ += horizontalOffset
-				}
-				if !isNetherPortalFrame(w, baseX, bottom, baseZ, axis) {
-					continue
-				}
-				changes := make([]BlockChange, 0, 6)
-				for horizontal := 1; horizontal <= 2; horizontal++ {
-					for vertical := 1; vertical <= 3; vertical++ {
-						x, z := baseX, baseZ
+		for interiorWidth := minNetherPortalInteriorWidth; interiorWidth <= maxNetherPortalInteriorWidth; interiorWidth++ {
+			outerWidth := interiorWidth + 2
+			for interiorHeight := minNetherPortalInteriorHeight; interiorHeight <= maxNetherPortalInteriorHeight; interiorHeight++ {
+				outerHeight := interiorHeight + 2
+
+				// The clicked obsidian may be anywhere on a required edge. Try every
+				// possible frame origin that could contain that clicked edge block.
+				for horizontalOffset := -(outerWidth - 1); horizontalOffset <= 0; horizontalOffset++ {
+					for verticalOffset := -(outerHeight - 1); verticalOffset <= 0; verticalOffset++ {
+						baseX, bottom, baseZ := clickedX, clickedY+verticalOffset, clickedZ
 						if axis == "x" {
-							x += horizontal
+							baseX += horizontalOffset
 						} else {
-							z += horizontal
+							baseZ += horizontalOffset
 						}
-						changes = append(changes, BlockChange{X: x, Y: bottom + vertical, Z: z, Block: Block{
-							Namespace: "minecraft", Name: "nether_portal", Properties: map[string]string{"axis": axis},
-						}})
+
+						clickedHorizontal := -horizontalOffset
+						clickedVertical := -verticalOffset
+						if !netherPortalRequiredEdge(clickedHorizontal, clickedVertical, outerWidth, outerHeight) {
+							continue
+						}
+						if !isNetherPortalFrame(w, baseX, bottom, baseZ, axis, outerWidth, outerHeight) {
+							continue
+						}
+
+						changes := make([]BlockChange, 0, interiorWidth*interiorHeight)
+						for horizontal := 1; horizontal < outerWidth-1; horizontal++ {
+							for vertical := 1; vertical < outerHeight-1; vertical++ {
+								x, z := baseX, baseZ
+								if axis == "x" {
+									x += horizontal
+								} else {
+									z += horizontal
+								}
+								changes = append(changes, BlockChange{
+									X: x, Y: bottom + vertical, Z: z,
+									Block: Block{Namespace: "minecraft", Name: "nether_portal", Properties: map[string]string{"axis": axis}},
+								})
+							}
+						}
+						return changes, true
 					}
 				}
-				return changes, true
 			}
 		}
 	}
 	return nil, false
 }
 
-func isNetherPortalFrame(w *World, baseX, bottom, baseZ int, axis string) bool {
-	for horizontal := 0; horizontal < 4; horizontal++ {
-		for vertical := 0; vertical < 5; vertical++ {
-			border := ((horizontal == 0 || horizontal == 3) && vertical >= 1 && vertical <= 3) ||
-				((vertical == 0 || vertical == 4) && horizontal >= 1 && horizontal <= 2)
-			interior := horizontal >= 1 && horizontal <= 2 && vertical >= 1 && vertical <= 3
+// netherPortalRequiredEdge reports whether a location in an outer frame is a
+// mandatory obsidian block. Corners deliberately return false: vanilla permits
+// all four corners to be omitted.
+func netherPortalRequiredEdge(horizontal, vertical, outerWidth, outerHeight int) bool {
+	if horizontal < 0 || horizontal >= outerWidth || vertical < 0 || vertical >= outerHeight {
+		return false
+	}
+	if (horizontal == 0 || horizontal == outerWidth-1) && vertical >= 1 && vertical <= outerHeight-2 {
+		return true
+	}
+	return (vertical == 0 || vertical == outerHeight-1) && horizontal >= 1 && horizontal <= outerWidth-2
+}
+
+func isNetherPortalFrame(w *World, baseX, bottom, baseZ int, axis string, outerWidth, outerHeight int) bool {
+	for horizontal := 0; horizontal < outerWidth; horizontal++ {
+		for vertical := 0; vertical < outerHeight; vertical++ {
+			requiredBorder := netherPortalRequiredEdge(horizontal, vertical, outerWidth, outerHeight)
+			interior := horizontal >= 1 && horizontal <= outerWidth-2 && vertical >= 1 && vertical <= outerHeight-2
+			if !requiredBorder && !interior {
+				continue // optional corner
+			}
+
 			x, z := baseX, baseZ
 			if axis == "x" {
 				x += horizontal
@@ -54,7 +95,7 @@ func isNetherPortalFrame(w *World, baseX, bottom, baseZ int, axis string) bool {
 				z += horizontal
 			}
 			block := w.GetBlock(x, bottom+vertical, z)
-			if border && block.ResourceLocation() != "minecraft:obsidian" {
+			if requiredBorder && block.ResourceLocation() != "minecraft:obsidian" {
 				return false
 			}
 			if interior && !netherPortalReplaceable(block.ResourceLocation()) {
@@ -68,7 +109,7 @@ func isNetherPortalFrame(w *World, baseX, bottom, baseZ int, axis string) bool {
 func netherPortalReplaceable(name string) bool {
 	switch name {
 	case "", "minecraft:air", "minecraft:cave_air", "minecraft:void_air", "minecraft:fire",
-		"minecraft:short_grass", "minecraft:grass", "minecraft:fern", "minecraft:tall_grass",
+		"minecraft:nether_portal", "minecraft:short_grass", "minecraft:grass", "minecraft:fern", "minecraft:tall_grass",
 		"minecraft:large_fern", "minecraft:dead_bush", "minecraft:snow", "minecraft:vine",
 		"minecraft:water", "minecraft:lava", "minecraft:dandelion", "minecraft:poppy",
 		"minecraft:blue_orchid", "minecraft:allium", "minecraft:azure_bluet",

--- a/core/world/portal_variable_size_test.go
+++ b/core/world/portal_variable_size_test.go
@@ -1,0 +1,70 @@
+package world
+
+import "testing"
+
+func buildTestPortalFrame(w *World, baseX, bottom, baseZ int, axis string, interiorWidth, interiorHeight int) {
+	outerWidth, outerHeight := interiorWidth+2, interiorHeight+2
+	for horizontal := 0; horizontal < outerWidth; horizontal++ {
+		for vertical := 0; vertical < outerHeight; vertical++ {
+			if !netherPortalRequiredEdge(horizontal, vertical, outerWidth, outerHeight) {
+				continue
+			}
+			x, z := baseX, baseZ
+			if axis == "x" {
+				x += horizontal
+			} else {
+				z += horizontal
+			}
+			w.SetBlock(x, bottom+vertical, z, Block{Namespace: "minecraft", Name: "obsidian"})
+		}
+	}
+}
+
+func TestNetherPortalInteriorAcceptsVanillaVariableSizeFrame(t *testing.T) {
+	w := New(&FlatGenerator{}, nil, false)
+	defer w.Close()
+
+	buildTestPortalFrame(w, 10, 64, 10, "x", 5, 6)
+	changes, ok := NetherPortalInterior(w, 10, 66, 10)
+	if !ok {
+		t.Fatal("expected a valid 5x6 interior portal frame")
+	}
+	if len(changes) != 30 {
+		t.Fatalf("portal changes = %d, want 30", len(changes))
+	}
+	for _, change := range changes {
+		if change.Block.ResourceLocation() != "minecraft:nether_portal" || change.Block.Properties["axis"] != "x" {
+			t.Fatalf("unexpected portal block: %s", change.Block.Key())
+		}
+	}
+}
+
+func TestNetherPortalInteriorAcceptsZAxisAndOptionalCorners(t *testing.T) {
+	w := New(&FlatGenerator{}, nil, false)
+	defer w.Close()
+
+	buildTestPortalFrame(w, -4, 70, 20, "z", 3, 4)
+	changes, ok := NetherPortalInterior(w, -4, 72, 20)
+	if !ok {
+		t.Fatal("expected valid z-axis portal without corner obsidian")
+	}
+	if len(changes) != 12 {
+		t.Fatalf("portal changes = %d, want 12", len(changes))
+	}
+	for _, change := range changes {
+		if change.Block.Properties["axis"] != "z" {
+			t.Fatalf("axis = %q, want z", change.Block.Properties["axis"])
+		}
+	}
+}
+
+func TestNetherPortalInteriorRejectsBrokenFrame(t *testing.T) {
+	w := New(&FlatGenerator{}, nil, false)
+	defer w.Close()
+
+	buildTestPortalFrame(w, 0, 64, 0, "x", 2, 3)
+	w.SetBlock(3, 66, 0, Air) // remove one mandatory side block
+	if _, ok := NetherPortalInterior(w, 0, 66, 0); ok {
+		t.Fatal("broken frame was accepted")
+	}
+}

--- a/java/handler/boat.go
+++ b/java/handler/boat.go
@@ -9,8 +9,8 @@ package handler
 // Relevant packets (Java 1.21.4 / protocol 769):
 //   CB  set_passengers  (0x65 = 101) — tells client who is riding what
 //   SB  move_vehicle    (0x1B = 27)  — client updates boat position while riding
-//   SB  player_input    (0x20 = 32)  — one-byte input flags; shift = dismount
-//   SB  player_command  (0x19 = 25)  — action 8 = leave vehicle
+//   SB  player_input    (0x20 = 32)  — input flags; shift = dismount
+//   SB  player_command  (0x19 = 25)  — action 8 = start fall flying (elytra)
 
 import (
 	"fmt"
@@ -54,13 +54,7 @@ func BroadcastSetPassengers(vehicleEntityID int32, passengerIDs []int32, mgr *se
 // ── Serverbound packet handlers ───────────────────────────────────────────────
 
 // HandleMoveVehiclePacket parses a SB Move Vehicle packet and updates the
-// boat's position in the world, then broadcasts it to all other players.
-//
-// Wire layout (1.21.4):
-//
-//	Double  x, y, z
-//	Float   yaw, pitch
-//	Bool    on_ground
+// vehicle position in the world, then broadcasts it to all other players.
 func HandleMoveVehiclePacket(pkt *protocol.Packet, p *coreplayer.Player, w *coreworld.World, conn *network.ClientConn, mgr *session.Manager, buses ...*intent.Bus) error {
 	r := pkt.Reader()
 
@@ -116,29 +110,22 @@ func HandleMoveVehiclePacket(pkt *protocol.Packet, p *coreplayer.Player, w *core
 		return nil
 	}
 
-	// Update boat position.
 	vehicle.Position.X = x
 	vehicle.Position.Y = y
 	vehicle.Position.Z = z
 	vehicle.Yaw = yaw
 	vehicle.OnGround = onGround
 
-	// Keep player's logical position in sync (chunk loading, /tp, etc.).
 	p.Position.X = x
 	p.Position.Y = y + 0.35
 	p.Position.Z = z
 
-	// Broadcast to all other clients.
 	broadcastBoatPositionExcept(vehicle, p.EntityID, mgr)
 	return nil
 }
 
 // HandlePlayerInputPacket parses a SB Player Input packet.
-// Shift flag (bit 5) = exit vehicle.
-//
-// Wire layout (1.21.4):
-//
-//	Unsigned Byte inputs (forward, backward, left, right, jump, shift, sprint)
+// Shift flag (bit 5) exits a vehicle.
 func HandlePlayerInputPacket(pkt *protocol.Packet, p *coreplayer.Player, w *coreworld.World, conn *network.ClientConn, mgr *session.Manager, buses ...*intent.Bus) error {
 	r := pkt.Reader()
 	flags, err := protocol.ReadByte(r)
@@ -156,13 +143,19 @@ func HandlePlayerInputPacket(pkt *protocol.Packet, p *coreplayer.Player, w *core
 }
 
 // HandlePlayerCommandPacket parses a SB Player Command packet.
-// Action 8 = leave vehicle.
 //
-// Wire layout (1.21.4):
+// Modern Java action IDs used here:
+//   0 = start sneaking
+//   1 = stop sneaking
+//   2 = leave bed
+//   3 = start sprinting
+//   4 = stop sprinting
+//   8 = start fall flying (elytra)
 //
-//	VarInt  entity_id
-//	VarInt  action  (8 = leave vehicle)
-//	VarInt  jump_boost
+// Previous GoCraft code incorrectly treated action 8 as LEAVE_VEHICLE. That
+// made an elytra start packet hit the vehicle path and left fall-flying state
+// effectively unsupported. Vehicle dismount remains handled by Player Input's
+// shift flag, which is the packet path used by modern clients.
 func HandlePlayerCommandPacket(pkt *protocol.Packet, p *coreplayer.Player, w *coreworld.World, conn *network.ClientConn, mgr *session.Manager, buses ...*intent.Bus) error {
 	r := pkt.Reader()
 	if _, err := protocol.ReadVarInt(r); err != nil {
@@ -172,6 +165,12 @@ func HandlePlayerCommandPacket(pkt *protocol.Packet, p *coreplayer.Player, w *co
 	if err != nil {
 		return fmt.Errorf("player_command: action: %w", err)
 	}
+	// jump_boost follows action on the wire. It is unused by these actions but
+	// consume it when present so malformed/truncated command packets are caught.
+	if _, err := protocol.ReadVarInt(r); err != nil {
+		return fmt.Errorf("player_command: jump_boost: %w", err)
+	}
+
 	switch action {
 	case 0: // START_SNEAKING
 		p.Sneaking = true
@@ -187,13 +186,13 @@ func HandlePlayerCommandPacket(pkt *protocol.Packet, p *coreplayer.Player, w *co
 		p.Sprinting = true
 	case 4: // STOP_SPRINTING
 		p.Sprinting = false
-	case 8: // LEAVE_VEHICLE
-		if p.VehicleEntityID != 0 {
-			if len(buses) > 0 && buses[0] != nil {
-				buses[0].PostEntityInteract(intent.EntityInteractIntent{PlayerUUID: p.UUID, TargetID: 0, HotbarSlot: int32(p.HeldSlot)})
-				break
-			}
-			DismountPlayer(p, w, conn, mgr)
+	case 8: // START_FALL_FLYING
+		// The client may only begin gliding while airborne with an elytra in the
+		// chest slot. The actual movement remains client-driven like ordinary
+		// Java movement; reset accumulated fall distance so starting a valid
+		// glide cannot immediately apply the pre-glide fall as landing damage.
+		if p.VehicleEntityID == 0 && !p.OnGround && p.Inventory[6].ItemID == "minecraft:elytra" {
+			p.FallDistance = 0
 		}
 	}
 	return nil
@@ -201,8 +200,6 @@ func HandlePlayerCommandPacket(pkt *protocol.Packet, p *coreplayer.Player, w *co
 
 // ── Mount / dismount ──────────────────────────────────────────────────────────
 
-// MountPlayer seats the player onto boat and broadcasts Set Passengers.
-// Returns false if the boat is not found or already occupied.
 func MountPlayer(p *coreplayer.Player, boatEntityID int32, w *coreworld.World, mgr *session.Manager) bool {
 	boat, ok := w.Entities.Get(boatEntityID)
 	if !ok || !corentity.IsBoat(boat.Type) {
@@ -216,8 +213,6 @@ func MountPlayer(p *coreplayer.Player, boatEntityID int32, w *coreworld.World, m
 	return true
 }
 
-// DismountPlayer ejects the player from their vehicle and teleports them to a
-// safe position beside the boat.
 func DismountPlayer(p *coreplayer.Player, w *coreworld.World, conn *network.ClientConn, mgr *session.Manager) {
 	boatID := p.VehicleEntityID
 	if boatID == 0 {

--- a/java/handler/builtins.go
+++ b/java/handler/builtins.go
@@ -234,7 +234,6 @@ func cmdList(ctx CommandContext) error {
 			if online != nil {
 				names = append(names, online.Username)
 			}
-		}
 		sort.Slice(names, func(i, j int) bool {
 			return strings.ToLower(names[i]) < strings.ToLower(names[j])
 		})
@@ -400,7 +399,7 @@ func cmdSummon(ctx CommandContext) error {
 
 	mobName := strings.ToLower(strings.TrimPrefix(ctx.Args[0], "minecraft:"))
 	if !containsName(summonableMobNames, mobName) {
-		return fmt.Errorf("unknown mob %q; use tab completion", mobName)
+		return fmt.Errorf("unknown mob %q; use tab completion", ctx.Args[0])
 	}
 
 	// Parse optional coordinates: /summon <mob> <x> <y> <z>

--- a/java/handler/builtins.go
+++ b/java/handler/builtins.go
@@ -400,7 +400,7 @@ func cmdSummon(ctx CommandContext) error {
 
 	mobName := strings.ToLower(strings.TrimPrefix(ctx.Args[0], "minecraft:"))
 	if !containsName(summonableMobNames, mobName) {
-		return fmt.Errorf("unknown mob %q; use tab completion", ctx.Args[0])
+		return fmt.Errorf("unknown mob %q; use tab completion", mobName)
 	}
 
 	// Parse optional coordinates: /summon <mob> <x> <y> <z>
@@ -585,33 +585,46 @@ func cmdTp(ctx CommandContext) error {
 		}
 	}
 
-	// /tp <player> — teleport self to player.
+	// /tp <player> — teleport self to the player's exact dimension and position.
+	// Cross-edition visibility is dimension-scoped, so copying coordinates alone
+	// can leave a Java and Bedrock player standing at the same XYZ in different
+	// worlds and therefore invisible to one another.
 	targetName := ctx.Args[0]
 	if ctx.FindPlayer != nil {
 		if target := ctx.FindPlayer(targetName); target != nil {
-			pos := target.Position
-			if ctx.TeleportTo == nil {
-				return fmt.Errorf(`teleport service is unavailable`)
-			}
-			if err := ctx.TeleportTo(pos.X, pos.Y, pos.Z); err != nil {
-				return fmt.Errorf(`teleporting: %w`, err)
-			}
-			_ = sendCommandMessage(ctx, fmt.Sprintf(`Teleported to %s`, target.Username))
-			return nil
+			return teleportSelfToPlayer(ctx, target)
 		}
 	}
-	for _, s := range ctx.Manager.SnapshotAll() {
-		if strings.EqualFold(s.Player.Username, targetName) {
-			pos := s.Player.Position
-			if err := ctx.TeleportTo(pos.X, pos.Y, pos.Z); err != nil {
-				return fmt.Errorf("teleporting: %w", err)
+	if ctx.Manager != nil {
+		for _, s := range ctx.Manager.SnapshotAll() {
+			if s.Player != nil && strings.EqualFold(s.Player.Username, targetName) {
+				return teleportSelfToPlayer(ctx, s.Player)
 			}
-			_ = sendSystemMessage(ctx.Conn,
-				fmt.Sprintf("Teleported to %s", s.Player.Username))
-			return nil
 		}
 	}
 	return fmt.Errorf("player not found: %s", targetName)
+}
+
+func teleportSelfToPlayer(ctx CommandContext, target *player.Player) error {
+	if ctx.Player == nil || target == nil {
+		return fmt.Errorf("player state is unavailable")
+	}
+	if ctx.TeleportTo == nil {
+		return fmt.Errorf("teleport service is unavailable")
+	}
+	if ctx.Player.Dimension != target.Dimension {
+		if ctx.ChangeWorld == nil {
+			return fmt.Errorf("dimension changing is unavailable")
+		}
+		if err := ctx.ChangeWorld(target.Dimension); err != nil {
+			return fmt.Errorf("changing dimension: %w", err)
+		}
+	}
+	pos := target.Position
+	if err := ctx.TeleportTo(pos.X, pos.Y, pos.Z); err != nil {
+		return fmt.Errorf("teleporting: %w", err)
+	}
+	return sendCommandMessage(ctx, fmt.Sprintf("Teleported to %s", target.Username))
 }
 
 func tpPlayerToCoords(ctx CommandContext, targetName string, x, y, z float64) error {

--- a/java/handler/health.go
+++ b/java/handler/health.go
@@ -255,6 +255,16 @@ func damagePlayer(target *session.Session, rawDamage float32, cause string, mgr 
 		BroadcastHurtAnimation(p.EntityID, p.Rotation.Yaw, mgr)
 	}
 	if died {
+		// Sleeping is a tracked client pose, not just a canonical bool. Clear it
+		// immediately when death wins so Java does not carry the bed pose through
+		// Respawn, and Bedrock's next sync observes the same standing state.
+		if p.Sleeping {
+			p.Sleeping = false
+			if mgr != nil {
+				BroadcastPlayerWaking(p.EntityID, mgr)
+			}
+		}
+
 		// Totem of undying: if the player holds one, prevent death.
 		if tryConsumeTotem(target) {
 			return true

--- a/java/handler/play.go
+++ b/java/handler/play.go
@@ -613,19 +613,21 @@ func playLoop(conn *network.ClientConn, p *player.Player, spawnTeleportID int32,
 		if streamRespawn {
 			streamRespawn = false
 			keys := chunkKeysAround(newCX, newCZ, viewRadius)
-			nearCount := 1
+			// A single centre chunk is not enough for modern Java clients to leave
+			// Loading terrain promptly. Bootstrap a bounded 5x5 area so respawn is
+			// immediately playable without synchronously sending the entire view.
+			bootstrapRadius := min(viewRadius, int32(2))
+			nearCount := int((bootstrapRadius*2 + 1) * (bootstrapRadius*2 + 1))
 			if len(keys) < nearCount {
 				nearCount = len(keys)
 			}
 			if err := sendChunkKeys(conn, w, sender, sentChunks, keys[:nearCount]); err != nil {
 				return fmt.Errorf(`send nearby respawn chunks: %w`, err)
 			}
-			// Generate only the immediately surrounding ring in the background.
-			// Queuing the full configured radius before the centre chunk used to
-			// starve the synchronous chunk request and leave the client stuck on
-			// Loading terrain (or a black destination dimension).
+			// Warm the same bootstrap radius. The rest remains background work so
+			// large configured view distances do not stall the respawn handshake.
 			if preGenerateRadius > 0 {
-				w.QueuePregeneration(newCX, newCZ, 1)
+				w.QueuePregeneration(newCX, newCZ, bootstrapRadius)
 			}
 			pendingRespawnChunks = append(pendingRespawnChunks, keys[nearCount:]...)
 			broadcastGeneratedEntities(w, mgr)
@@ -709,7 +711,7 @@ func playLoop(conn *network.ClientConn, p *player.Player, spawnTeleportID int32,
 		}
 		broadcastGeneratedEntities(w, mgr)
 		if len(pendingRespawnChunks) > 0 {
-			batchSize := 4
+			batchSize := 16
 			if len(pendingRespawnChunks) < batchSize {
 				batchSize = len(pendingRespawnChunks)
 			}

--- a/java/handler/tp_dimension_test.go
+++ b/java/handler/tp_dimension_test.go
@@ -1,0 +1,77 @@
+package handler
+
+import (
+	"testing"
+
+	"GoCraft/core/player"
+	"GoCraft/core/spatial"
+)
+
+func TestTeleportSelfToPlayerChangesDimensionBeforePosition(t *testing.T) {
+	issuer := player.New([16]byte{1}, "Issuer", player.ClientEditionJava)
+	issuer.Dimension = 0
+	target := player.New([16]byte{2}, "Target", player.ClientEditionBedrock)
+	target.Dimension = 1
+	target.Position = spatial.Vec3{X: 123.5, Y: 70, Z: -44.25}
+
+	changedDimension := int32(-1)
+	teleported := spatial.Vec3{}
+	ctx := CommandContext{
+		Player: issuer,
+		Args:   []string{"Target"},
+		FindPlayer: func(name string) *player.Player {
+			if name == "Target" {
+				return target
+			}
+			return nil
+		},
+		ChangeWorld: func(dimension int32) error {
+			changedDimension = dimension
+			issuer.Dimension = dimension
+			return nil
+		},
+		TeleportTo: func(x, y, z float64) error {
+			teleported = spatial.Vec3{X: x, Y: y, Z: z}
+			return nil
+		},
+		Reply: func(string) error { return nil },
+	}
+
+	if err := cmdTp(ctx); err != nil {
+		t.Fatalf("cmdTp returned error: %v", err)
+	}
+	if changedDimension != target.Dimension {
+		t.Fatalf("dimension change = %d, want %d", changedDimension, target.Dimension)
+	}
+	if teleported != target.Position {
+		t.Fatalf("teleport position = %+v, want %+v", teleported, target.Position)
+	}
+}
+
+func TestTeleportSelfToPlayerSameDimensionSkipsWorldChange(t *testing.T) {
+	issuer := player.New([16]byte{3}, "Issuer", player.ClientEditionJava)
+	issuer.Dimension = 0
+	target := player.New([16]byte{4}, "Target", player.ClientEditionBedrock)
+	target.Dimension = 0
+	target.Position = spatial.Vec3{X: 20, Y: 65, Z: 20}
+
+	worldChanged := false
+	ctx := CommandContext{
+		Player: issuer,
+		Args:   []string{"Target"},
+		FindPlayer: func(string) *player.Player { return target },
+		ChangeWorld: func(int32) error {
+			worldChanged = true
+			return nil
+		},
+		TeleportTo: func(x, y, z float64) error { return nil },
+		Reply:      func(string) error { return nil },
+	}
+
+	if err := cmdTp(ctx); err != nil {
+		t.Fatalf("cmdTp returned error: %v", err)
+	}
+	if worldChanged {
+		t.Fatal("same-dimension /tp unexpectedly changed world")
+	}
+}


### PR DESCRIPTION
Fixes the confirmed regressions from the gameplay bug batch.

Implemented:
- repair the broken `core/helper/NewChestManager.go` compilation blocker on `main`
- fix Nether portal ignition: frames are no longer restricted to exact 4x5; vanilla interior sizes 2x3 through 21x21 work on both axes with optional corners
- fix Java `player_command` action 8: protocol 769 uses START_FALL_FLYING (elytra), not LEAVE_VEHICLE
- keep vehicle dismount on the Player Input sneak path
- add variable-size Nether portal regression tests
- clear the sleeping pose immediately on lethal damage so a player cannot respawn still visually lying in bed
- accelerate Java respawn: synchronously bootstrap a bounded 5x5 destination area instead of only one chunk, then stream remaining respawn chunks in batches of 16
- fix `/tp <player>` across dimensions: the issuing player changes to the target player's dimension before being moved to the target position
- fix Bedrock visibility after teleport-sized Java movement: remote jumps larger than 8 blocks use Bedrock `MoveModeTeleport` instead of `MoveModeNormal`
- add regression tests for cross-dimension `/tp` and Bedrock remote teleport movement mode

Verification:
- CI on the implementation head before the final regression-test/cleanup commits: Build passing, go vet passing, tests passing
- latest regression-test/cleanup head is being rechecked by CI

Already present / verified rather than duplicated:
- `/world`, `/world overworld`, `/world nether`, `/world end` are already registered and included in the Java command graph
- projectile simulation already exists in the server tick; the reported arrow issue needs its exact failing behaviour isolated rather than adding a second physics loop

Still intentionally pending in this draft:
- right-click/composter spam and the reported sneak-right-click case
- trapdoor reproduction case
- exact arrow symptom
- burst-hit (`900 coup d'un coup`) reproduction/protocol path
- directional wooden-block visual flip
- bat-specific AI behaviour
- donkey hit/rear animation behaviour
- `1 MARCHE TJS PAS` (the referenced item is not identifiable from the report alone)
