### PR TITLE
fix: vanilla interaction parity — bells, fireworks, signs, banners, wall torches

### DIFF
--- a/bedrock/bell.go
+++ b/bedrock/bell.go
@@ -1,0 +1,59 @@
+package bedrock
+
+import (
+	"GoCraft/core/spatial"
+
+	"github.com/go-gl/mathgl/mgl32"
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+)
+
+func bedrockBellPackets(position spatial.BlockPos, direction string) [2]packet.Packet {
+	blockPosition := protocol.BlockPos{position.X, position.Y, position.Z}
+	return [2]packet.Packet{
+		&packet.BlockActorData{Position: blockPosition, NBTData: map[string]any{
+			"id": "Bell", "x": position.X, "y": position.Y, "z": position.Z,
+			"Direction": bedrockBellDirection(direction), "Ringing": uint8(1), "Ticks": int32(0),
+		}},
+		&packet.LevelSoundEvent{
+			SoundType: packet.SoundEventBell,
+			Position:  mgl32.Vec3{float32(position.X) + 0.5, float32(position.Y) + 0.5, float32(position.Z) + 0.5},
+			ExtraData: -1,
+		},
+	}
+}
+
+func bedrockBellDirection(direction string) int32 {
+	switch direction {
+	case "west":
+		return 1
+	case "north":
+		return 2
+	case "east":
+		return 3
+	default:
+		return 0
+	}
+}
+
+// BroadcastBellRing mirrors one canonical bell action to Bedrock viewers in
+// the same dimension using a transient block actor animation and bell sound.
+func (l *Listener) BroadcastBellRing(dimension int32, position spatial.BlockPos, direction string) {
+	if l == nil {
+		return
+	}
+	packets := bedrockBellPackets(position, direction)
+	l.sessionsMu.RLock()
+	sessions := make([]*bedrockSession, 0, len(l.sessions))
+	for _, current := range l.sessions {
+		if current.dimension.Load() == dimension {
+			sessions = append(sessions, current)
+		}
+	}
+	l.sessionsMu.RUnlock()
+	for _, current := range sessions {
+		for _, event := range packets {
+			_ = current.conn.WritePacket(event)
+		}
+	}
+}

--- a/bedrock/bell_test.go
+++ b/bedrock/bell_test.go
@@ -1,0 +1,21 @@
+package bedrock
+
+import (
+	"testing"
+
+	"GoCraft/core/spatial"
+
+	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+)
+
+func TestBedrockBellUsesBlockActorAnimationAndNativeSound(t *testing.T) {
+	packets := bedrockBellPackets(spatial.BlockPos{X: 1, Y: 64, Z: 2}, "east")
+	actor, ok := packets[0].(*packet.BlockActorData)
+	if !ok || actor.NBTData["id"] != "Bell" || actor.NBTData["Direction"] != int32(3) || actor.NBTData["Ringing"] != uint8(1) {
+		t.Fatalf("block actor=%#v", packets[0])
+	}
+	sound, ok := packets[1].(*packet.LevelSoundEvent)
+	if !ok || sound.SoundType != packet.SoundEventBell {
+		t.Fatalf("sound=%#v", packets[1])
+	}
+}

--- a/bedrock/creative.go
+++ b/bedrock/creative.go
@@ -19,8 +19,10 @@ import (
 // creativeKnownItem is the canonical identity associated with a creative
 // network ID. The simulation uses this when a Bedrock player selects an item.
 type creativeKnownItem struct {
-	name string
-	meta int16
+	name         string
+	meta         int16
+	hasFireworks bool
+	fireworks    player.FireworkData
 }
 
 type creativeBedrockIdentity struct {
@@ -185,7 +187,11 @@ func (l *Listener) initCreativeContent() {
 			GroupIndex:            entry.group,
 		})
 		canonicalName, canonicalMeta := canonicalCreativeIdentity(entry.name, entry.meta)
-		l.creativeNames[creativeNetworkID] = creativeKnownItem{name: canonicalName, meta: canonicalMeta}
+		known := creativeKnownItem{name: canonicalName, meta: canonicalMeta}
+		if canonicalName == "minecraft:firework_rocket" {
+			known.fireworks, known.hasFireworks = bedrockFireworkDataFromNBT(stack.NBTData)
+		}
+		l.creativeNames[creativeNetworkID] = known
 	}
 
 	debuglog.Info(debuglog.BedrockCatalogues,

--- a/bedrock/firework.go
+++ b/bedrock/firework.go
@@ -1,0 +1,166 @@
+package bedrock
+
+import (
+	"GoCraft/core/player"
+	"GoCraft/core/spatial"
+
+	"github.com/go-gl/mathgl/mgl32"
+	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+)
+
+var fireworkDyeColours = [...]int32{
+	0xf0f0f0, 0xf9801d, 0xc74ebd, 0x3ab3da,
+	0xfed83d, 0x80c71f, 0xf38baa, 0x474f52,
+	0x9d9d97, 0x169c9c, 0x8932b8, 0x3c44aa,
+	0x835432, 0x5e7c16, 0xb02e26, 0x1d1d21,
+}
+
+func bedrockFireworkDataFromNBT(data map[string]any) (player.FireworkData, bool) {
+	root, ok := data["Fireworks"].(map[string]any)
+	if !ok {
+		return player.FireworkData{}, false
+	}
+	result := player.FireworkData{Flight: uint8(clampInt(nbtInt(root["Flight"]), 0, 255))}
+	for _, value := range nbtList(root["Explosions"]) {
+		entry, ok := value.(map[string]any)
+		if !ok || result.ExplosionCount >= player.MaxFireworkExplosions {
+			continue
+		}
+		explosion := &result.Explosions[result.ExplosionCount]
+		explosion.Shape = uint8(clampInt(nbtInt(entry["FireworkType"]), 0, 4))
+		explosion.Twinkle = nbtInt(entry["FireworkFlicker"]) != 0
+		explosion.Trail = nbtInt(entry["FireworkTrail"]) != 0
+		readBedrockFireworkColours(entry["FireworkColor"], &explosion.Colors, &explosion.ColorCount)
+		readBedrockFireworkColours(entry["FireworkFade"], &explosion.FadeColors, &explosion.FadeColorCount)
+		result.ExplosionCount++
+	}
+	return result, true
+}
+
+func bedrockFireworkNBT(data player.FireworkData) map[string]any {
+	data = player.ItemStack{ItemID: "minecraft:firework_rocket", HasFireworks: true, Fireworks: data}.EffectiveFireworks()
+	explosions := make([]any, 0, data.ExplosionCount)
+	for index := 0; index < int(data.ExplosionCount); index++ {
+		explosion := data.Explosions[index]
+		explosions = append(explosions, map[string]any{
+			"FireworkType":    uint8(explosion.Shape),
+			"FireworkColor":   bedrockFireworkColours(explosion.Colors, explosion.ColorCount),
+			"FireworkFade":    bedrockFireworkColours(explosion.FadeColors, explosion.FadeColorCount),
+			"FireworkFlicker": boolByte(explosion.Twinkle),
+			"FireworkTrail":   boolByte(explosion.Trail),
+		})
+	}
+	return map[string]any{"Fireworks": map[string]any{
+		"Flight": data.Flight, "Explosions": explosions,
+	}}
+}
+
+func readBedrockFireworkColours(value any, colours *[player.MaxFireworkColors]int32, count *uint8) {
+	for _, raw := range nbtList(value) {
+		if *count >= player.MaxFireworkColors {
+			return
+		}
+		index := uint8(nbtInt(raw)) ^ 15
+		if int(index) >= len(fireworkDyeColours) {
+			continue
+		}
+		colours[*count] = fireworkDyeColours[index]
+		*count++
+	}
+}
+
+func bedrockFireworkColours(colours [player.MaxFireworkColors]int32, count uint8) []uint8 {
+	out := make([]uint8, 0, count)
+	for index := 0; index < int(count) && index < len(colours); index++ {
+		out = append(out, nearestFireworkDye(colours[index])^15)
+	}
+	return out
+}
+
+func nearestFireworkDye(rgb int32) uint8 {
+	best, bestDistance := uint8(0), int64(1<<63-1)
+	for index, candidate := range fireworkDyeColours {
+		dr := int64((rgb>>16)&0xff) - int64((candidate>>16)&0xff)
+		dg := int64((rgb>>8)&0xff) - int64((candidate>>8)&0xff)
+		db := int64(rgb&0xff) - int64(candidate&0xff)
+		if distance := dr*dr + dg*dg + db*db; distance < bestDistance {
+			best, bestDistance = uint8(index), distance
+		}
+	}
+	return best
+}
+
+func nbtList(value any) []any {
+	switch values := value.(type) {
+	case []any:
+		return values
+	case []uint8:
+		out := make([]any, len(values))
+		for index, value := range values {
+			out[index] = value
+		}
+		return out
+	case [1]uint8:
+		return []any{values[0]}
+	default:
+		return nil
+	}
+}
+
+func nbtInt(value any) int {
+	switch number := value.(type) {
+	case uint8:
+		return int(number)
+	case int8:
+		return int(number)
+	case int16:
+		return int(number)
+	case int32:
+		return int(number)
+	case int:
+		return number
+	default:
+		return 0
+	}
+}
+
+func clampInt(value, low, high int) int { return min(max(value, low), high) }
+func boolByte(value bool) uint8 {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+// BroadcastFireworkExplosion translates a canonical rocket expiry for Bedrock viewers.
+func (l *Listener) BroadcastFireworkExplosion(dimension, entityID int32) {
+	l.broadcastDimension(dimension, &packet.ActorEvent{
+		EntityRuntimeID: bedrockRemoteRuntimeID(entityID), EventType: packet.ActorEventFireworksExplode,
+	})
+}
+
+// BroadcastFireworkLaunch translates the shared launch sound for Bedrock viewers.
+func (l *Listener) BroadcastFireworkLaunch(dimension int32, position spatial.Vec3) {
+	l.broadcastDimension(dimension, &packet.LevelSoundEvent{
+		SoundType: packet.SoundEventLaunch,
+		Position:  mgl32.Vec3{float32(position.X), float32(position.Y), float32(position.Z)},
+		ExtraData: -1,
+	})
+}
+
+func (l *Listener) broadcastDimension(dimension int32, value packet.Packet) {
+	if l == nil {
+		return
+	}
+	l.sessionsMu.RLock()
+	sessions := make([]*bedrockSession, 0, len(l.sessions))
+	for _, current := range l.sessions {
+		if current.dimension.Load() == dimension {
+			sessions = append(sessions, current)
+		}
+	}
+	l.sessionsMu.RUnlock()
+	for _, current := range sessions {
+		_ = current.conn.WritePacket(value)
+	}
+}

--- a/bedrock/firework_test.go
+++ b/bedrock/firework_test.go
@@ -1,0 +1,67 @@
+package bedrock
+
+import (
+	"testing"
+
+	"GoCraft/core/player"
+	coreworld "GoCraft/core/world"
+)
+
+func TestBedrockFireworkNBTRoundTrip(t *testing.T) {
+	want := player.FireworkData{Flight: 3, ExplosionCount: 1}
+	want.Explosions[0] = player.FireworkExplosion{
+		Shape: 4, Colors: [player.MaxFireworkColors]int32{0xb02e26, 0x3c44aa}, ColorCount: 2,
+		FadeColors: [player.MaxFireworkColors]int32{0xfed83d}, FadeColorCount: 1,
+		Trail: true, Twinkle: true,
+	}
+	got, ok := bedrockFireworkDataFromNBT(bedrockFireworkNBT(want))
+	if !ok {
+		t.Fatal("firework NBT was not recognised")
+	}
+	if got != want {
+		t.Fatalf("round trip mismatch: got %+v, want %+v", got, want)
+	}
+}
+
+func TestBedrockSignAndBannerBlockActorData(t *testing.T) {
+	sign := bedrockBlockEntityData(coreworld.BlockEntity{X: 1, Y: 64, Z: 2, Type: "minecraft:sign"}, coreworld.Block{})
+	if sign["id"] != "Sign" || sign["FrontText"] == nil || sign["BackText"] == nil {
+		t.Fatalf("sign actor data = %#v", sign)
+	}
+	banner := bedrockBlockEntityData(coreworld.BlockEntity{Type: "minecraft:banner"}, coreworld.Block{
+		Namespace: "minecraft", Name: "red_wall_banner",
+	})
+	if banner["id"] != "Banner" || banner["Base"] != int32(1) {
+		t.Fatalf("red banner actor data = %#v", banner)
+	}
+}
+
+func TestBedrockFireworkNBTBounds(t *testing.T) {
+	got, ok := bedrockFireworkDataFromNBT(map[string]any{"Fireworks": map[string]any{
+		"Flight": uint8(9),
+		"Explosions": []any{map[string]any{
+			"FireworkType": uint8(9), "FireworkColor": []uint8{15},
+		}},
+	}})
+	if !ok || got.Flight != 9 || got.ExplosionCount != 1 || got.Explosions[0].Shape != 4 {
+		t.Fatalf("unexpected bounded data: %+v, ok=%v", got, ok)
+	}
+}
+
+func TestCreativeFireworkVariantsKeepCanonicalComponents(t *testing.T) {
+	l := &Listener{}
+	l.initCreativeContent()
+	var rockets, effectRockets int
+	for _, item := range l.creativeNames {
+		if item.name != "minecraft:firework_rocket" {
+			continue
+		}
+		rockets++
+		if item.hasFireworks && item.fireworks.ExplosionCount > 0 {
+			effectRockets++
+		}
+	}
+	if rockets < 2 || effectRockets == 0 {
+		t.Fatalf("creative rockets = %d total/%d with effects", rockets, effectRockets)
+	}
+}

--- a/bedrock/listener.go
+++ b/bedrock/listener.go
@@ -1644,9 +1644,11 @@ func (l *Listener) canonicalInventoryActions(
 				Destination: intent.InventoryCursorSlot,
 				Count:       count,
 				Item: player.ItemStack{
-					ItemID: ki.name,
-					Count:  count,
-					Damage: int(ki.meta),
+					ItemID:       ki.name,
+					Count:        count,
+					Damage:       int(ki.meta),
+					HasFireworks: ki.hasFireworks,
+					Fireworks:    ki.fireworks,
 				},
 			})
 			creativeSelected = true

--- a/bedrock/sync.go
+++ b/bedrock/sync.go
@@ -760,8 +760,10 @@ func (l *Listener) buildAddEntity(viewer *bedrockSession, entity *corentity.Enti
 
 func (l *Listener) bedrockEntityMetadata(viewer *bedrockSession, entity *corentity.Entity) protocol.EntityMetadata {
 	metadata := protocol.NewEntityMetadata()
-	metadata.SetFlag(protocol.EntityDataKeyFlags, protocol.EntityDataFlagHasGravity)
-	metadata.SetFlag(protocol.EntityDataKeyFlags, protocol.EntityDataFlagHasCollision)
+	if entity == nil || entity.Type != corentity.TypeFireworkRocket {
+		metadata.SetFlag(protocol.EntityDataKeyFlags, protocol.EntityDataFlagHasGravity)
+		metadata.SetFlag(protocol.EntityDataKeyFlags, protocol.EntityDataFlagHasCollision)
+	}
 	if entity == nil {
 		return metadata
 	}
@@ -817,6 +819,9 @@ func (l *Listener) bedrockEntityMetadata(viewer *bedrockSession, entity *corenti
 	if entity.Type == corentity.TypeFallingBlock && entity.FallingBlockName != "" && l != nil && l.encoder != nil {
 		block := splitBlockName(entity.FallingBlockName)
 		metadata[protocol.EntityDataKeyVariant] = int32(l.encoder.BlockNetworkID(block))
+	}
+	if entity.Type == corentity.TypeFireworkRocket {
+		metadata[protocol.EntityDataKeyDisplayFirework] = bedrockFireworkNBT(entity.FireworkData)
 	}
 	return metadata
 }
@@ -1785,6 +1790,8 @@ func bedrockEntityType(entityType corentity.EntityType) string {
 		return "minecraft:bamboo_raft"
 	case corentity.TypeBambooChestRaft:
 		return "minecraft:bamboo_chest_raft"
+	case corentity.TypeFireworkRocket:
+		return "minecraft:fireworks_rocket"
 	default:
 		return string(entityType)
 	}
@@ -1950,6 +1957,11 @@ func (l *Listener) itemInstance(stack player.ItemStack, stackNetworkID int32) pr
 		nbtData["id"] = "DecoratedPot"
 		nbtData["sherds"] = sherds
 	}
+	if stack.ItemID == "minecraft:firework_rocket" {
+		for key, value := range bedrockFireworkNBT(stack.EffectiveFireworks()) {
+			nbtData[key] = value
+		}
+	}
 	if len(nbtData) == 0 {
 		nbtData = nil
 	}
@@ -2057,17 +2069,20 @@ func armSizeToUint8(s string) uint8 {
 	return protocol.ArmSizeWide
 }
 
-// BroadcastBlockEntityData mirrors canonical decorated-pot block actor data to
+// BroadcastBlockEntityData translates canonical block-entity state for
 // Bedrock viewers in the affected dimension.
 func (l *Listener) BroadcastBlockEntityData(dimension int32, entity coreworld.BlockEntity) {
-	if l == nil || (entity.Type != "minecraft:decorated_pot" && entity.Type != "decorated_pot") {
+	if l == nil {
 		return
 	}
-	decorations := player.NormalizePotDecorations(entity.PotDecorations)
-	data := map[string]any{
-		"id": "DecoratedPot",
-		"x":  int32(entity.X), "y": int32(entity.Y), "z": int32(entity.Z),
-		"sherds": []string{decorations[0], decorations[1], decorations[2], decorations[3]},
+	dimensionWorld := l.worldForDimension(dimension)
+	if dimensionWorld == nil {
+		return
+	}
+	block := dimensionWorld.GetBlock(entity.X, entity.Y, entity.Z)
+	data := bedrockBlockEntityData(entity, block)
+	if data == nil {
+		return
 	}
 	l.sessionsMu.RLock()
 	sessions := make([]*bedrockSession, 0, len(l.sessions))
@@ -2083,4 +2098,49 @@ func (l *Listener) BroadcastBlockEntityData(dimension int32, entity coreworld.Bl
 			NBTData:  data,
 		})
 	}
+}
+
+func bedrockBlockEntityData(entity coreworld.BlockEntity, block coreworld.Block) map[string]any {
+	position := map[string]any{"x": int32(entity.X), "y": int32(entity.Y), "z": int32(entity.Z)}
+	switch strings.TrimPrefix(entity.Type, "minecraft:") {
+	case "decorated_pot":
+		decorations := player.NormalizePotDecorations(entity.PotDecorations)
+		position["id"] = "DecoratedPot"
+		position["sherds"] = []string{decorations[0], decorations[1], decorations[2], decorations[3]}
+	case "sign", "hanging_sign":
+		position["id"] = "Sign"
+		position["IsWaxed"] = uint8(0)
+		position["FrontText"] = emptyBedrockSignSide()
+		position["BackText"] = emptyBedrockSignSide()
+	case "banner":
+		position["id"] = "Banner"
+		position["Base"] = bedrockBannerBase(block.ResourceLocation())
+		position["Patterns"] = []any{}
+		position["Type"] = int32(0)
+	default:
+		return nil
+	}
+	return position
+}
+
+func emptyBedrockSignSide() map[string]any {
+	return map[string]any{
+		"SignTextColor": int32(-16777216), "IgnoreLighting": uint8(0),
+		"Text": "", "TextOwner": "", "PersistFormatting": uint8(1),
+	}
+}
+
+func bedrockBannerBase(name string) int32 {
+	colours := []string{
+		"white", "orange", "magenta", "light_blue", "yellow", "lime", "pink", "gray",
+		"light_gray", "cyan", "purple", "blue", "brown", "green", "red", "black",
+	}
+	base := strings.TrimPrefix(name, "minecraft:")
+	base = strings.TrimSuffix(strings.TrimSuffix(base, "_wall_banner"), "_banner")
+	for index, colour := range colours {
+		if base == colour {
+			return int32(index ^ 15)
+		}
+	}
+	return 15
 }

--- a/bedrock/world/encoder.go
+++ b/bedrock/world/encoder.go
@@ -280,13 +280,32 @@ func alternateBlockNames(name string) []string {
 	case "minecraft:short_grass":
 		return []string{"minecraft:tallgrass"}
 	}
+	if strings.HasSuffix(name, "_wall_banner") {
+		return []string{"minecraft:wall_banner"}
+	}
+	if strings.HasSuffix(name, "_banner") {
+		return []string{"minecraft:standing_banner"}
+	}
 	if strings.HasSuffix(name, "_wall_sign") {
-		return []string{strings.TrimSuffix(name, "_wall_sign") + "_wall_sign"}
+		wood := strings.TrimSuffix(strings.TrimPrefix(name, "minecraft:"), "_wall_sign")
+		return []string{"minecraft:" + bedrockSignWood(wood) + "wall_sign"}
 	}
 	if strings.HasSuffix(name, "_sign") {
-		return []string{strings.TrimSuffix(name, "_sign") + "_standing_sign"}
+		wood := strings.TrimSuffix(strings.TrimPrefix(name, "minecraft:"), "_sign")
+		return []string{"minecraft:" + bedrockSignWood(wood) + "standing_sign"}
 	}
 	return nil
+}
+
+func bedrockSignWood(wood string) string {
+	switch wood {
+	case "oak":
+		return ""
+	case "dark_oak":
+		return "darkoak_"
+	default:
+		return wood + "_"
+	}
 }
 
 func translateBlockProperties(block coreworld.Block) map[string]any {
@@ -317,6 +336,8 @@ func translateBlockProperties(block coreworld.Block) map[string]any {
 			}
 			if raw == "up" {
 				out["torch_facing_direction"] = "top"
+			} else if isBedrockWallTorch(block) {
+				out["torch_facing_direction"] = oppositeCardinal(raw)
 			} else {
 				out["torch_facing_direction"] = raw
 			}
@@ -438,6 +459,27 @@ func translateBlockProperties(block coreworld.Block) map[string]any {
 		out["wall_post_bit"] = boolByte(properties["up"] == "true")
 	}
 	return out
+}
+
+func isBedrockWallTorch(block coreworld.Block) bool {
+	name := block.ResourceLocation()
+	return name == "minecraft:wall_torch" || strings.HasSuffix(name, "_wall_torch") ||
+		(name == "minecraft:unlit_redstone_torch" && block.Properties["facing"] != "")
+}
+
+func oppositeCardinal(facing string) string {
+	switch facing {
+	case "north":
+		return "south"
+	case "south":
+		return "north"
+	case "west":
+		return "east"
+	case "east":
+		return "west"
+	default:
+		return facing
+	}
 }
 
 func rotateCardinalRight(facing string) string {

--- a/bedrock/world/encoder_actions_test.go
+++ b/bedrock/world/encoder_actions_test.go
@@ -22,7 +22,23 @@ func TestActionBlockStatesTranslateToBedrockPalette(t *testing.T) {
 		},
 		{
 			name: "wall torch", block: coreworld.Block{Namespace: "minecraft", Name: "wall_torch", Properties: map[string]string{"facing": "north"}},
-			wantName: "minecraft:torch", wantState: "torch_facing_direction", wantValue: "north",
+			wantName: "minecraft:torch", wantState: "torch_facing_direction", wantValue: "south",
+		},
+		{
+			name: "oak wall sign", block: coreworld.Block{Namespace: "minecraft", Name: "oak_wall_sign", Properties: map[string]string{"facing": "north"}},
+			wantName: "minecraft:wall_sign", wantState: "facing_direction", wantValue: int32(2),
+		},
+		{
+			name: "dark oak standing sign", block: coreworld.Block{Namespace: "minecraft", Name: "dark_oak_sign", Properties: map[string]string{"rotation": "7"}},
+			wantName: "minecraft:darkoak_standing_sign", wantState: "ground_sign_direction", wantValue: int32(7),
+		},
+		{
+			name: "standing banner", block: coreworld.Block{Namespace: "minecraft", Name: "white_banner", Properties: map[string]string{"rotation": "3"}},
+			wantName: "minecraft:standing_banner", wantState: "ground_sign_direction", wantValue: int32(3),
+		},
+		{
+			name: "wall banner", block: coreworld.Block{Namespace: "minecraft", Name: "red_wall_banner", Properties: map[string]string{"facing": "east"}},
+			wantName: "minecraft:wall_banner", wantState: "facing_direction", wantValue: int32(5),
 		},
 		{
 			name: "powered lever", block: coreworld.Block{Namespace: "minecraft", Name: "lever", Properties: map[string]string{"face": "wall", "facing": "north", "powered": "true"}},

--- a/core/entity/entity.go
+++ b/core/entity/entity.go
@@ -4,7 +4,10 @@
 // packages; this package uses only canonical resource-location strings.
 package entity
 
-import "GoCraft/core/spatial"
+import (
+	"GoCraft/core/player"
+	"GoCraft/core/spatial"
+)
 
 // EntityType is the canonical resource location for a Minecraft entity type,
 // e.g. "minecraft:cow".
@@ -94,6 +97,7 @@ const (
 	TypeSmallFireball    EntityType = "minecraft:small_fireball"
 	TypeFireball         EntityType = "minecraft:fireball"
 	TypeEyeOfEnder       EntityType = "minecraft:eye_of_ender"
+	TypeFireworkRocket   EntityType = "minecraft:firework_rocket"
 	TypeWanderingTrader  EntityType = "minecraft:wandering_trader"
 
 	// ── Boats ────────────────────────────────────────────────────────────────
@@ -250,6 +254,10 @@ type Entity struct {
 	EyeTarget        spatial.Vec3
 	HasEyeTarget     bool
 	EyeSurvives      bool
+	// Firework fields hold the canonical component and server-side lifetime.
+	FireworkData      player.FireworkData
+	FireworkLifeTicks int32
+	FireworkLifetime  int32
 
 	// Dropped-item fields. These are used only when Type == TypeItem and are
 	// encoded as the ItemEntity's tracked ItemStack at metadata index 8.
@@ -480,7 +488,7 @@ func defaultMaxHealth(t EntityType) float32 {
 	// Villager
 	case TypeVillager:
 		return 20
-	case TypeItem, TypeExperienceOrb, TypeArrow, TypeSpectralArrow, TypeTrident, TypeWindCharge:
+	case TypeItem, TypeExperienceOrb, TypeArrow, TypeSpectralArrow, TypeTrident, TypeWindCharge, TypeFireworkRocket:
 		return 1
 
 	// Boats
@@ -553,7 +561,7 @@ func IsProjectile(t EntityType) bool {
 	switch t {
 	case TypeArrow, TypeSpectralArrow, TypeTrident, TypeWindCharge,
 		TypeSnowball, TypeEgg, TypeEnderPearl, TypeExperienceBottle,
-		TypePotion, TypeSmallFireball, TypeFireball, TypeEyeOfEnder:
+		TypePotion, TypeSmallFireball, TypeFireball, TypeEyeOfEnder, TypeFireworkRocket:
 		return true
 	}
 	return false

--- a/core/intent/intent.go
+++ b/core/intent/intent.go
@@ -123,6 +123,23 @@ type BlockInteractIntent struct {
 	ClickZ     float32
 }
 
+// BellRingIntent asks the simulation to validate and ring one canonical bell.
+// Java posts this instead of mutating the world from its connection goroutine.
+type BellRingIntent struct {
+	PlayerUUID [16]byte
+	Position   spatial.BlockPos
+	Face       int32
+	HitY       float32
+}
+
+// FireworkUseIntent asks the simulation to launch the rocket from the
+// action-time hotbar stack at the exact clicked position.
+type FireworkUseIntent struct {
+	PlayerUUID [16]byte
+	HotbarSlot int32
+	Position   spatial.Vec3
+}
+
 // ConsumeFoodIntent requests consumption from the Bedrock hotbar slot captured
 // when the client completed its use-item animation. It does not change the
 // player's newer persistent selection.
@@ -270,6 +287,8 @@ func (DisconnectIntent) isLifecycle()        {}
 func (ChatIntent) isGameplay()               {}
 func (TeleportIntent) isGameplay()           {}
 func (BlockInteractIntent) isGameplay()      {}
+func (BellRingIntent) isGameplay()           {}
+func (FireworkUseIntent) isGameplay()        {}
 func (ConsumeFoodIntent) isGameplay()        {}
 func (StartUseItemIntent) isGameplay()       {}
 func (ArmSwingIntent) isGameplay()           {}
@@ -365,6 +384,8 @@ func (b *Bus) PostTeleport(i TeleportIntent) bool {
 }
 
 func (b *Bus) PostBlockInteract(i BlockInteractIntent) bool   { return b.tryGameplay(i) }
+func (b *Bus) PostBellRing(i BellRingIntent) bool             { return b.tryGameplay(i) }
+func (b *Bus) PostFireworkUse(i FireworkUseIntent) bool       { return b.tryGameplay(i) }
 func (b *Bus) PostConsumeFood(i ConsumeFoodIntent) bool       { return b.tryGameplay(i) }
 func (b *Bus) PostStartUseItem(i StartUseItemIntent) bool     { return b.tryGameplay(i) }
 func (b *Bus) PostArmSwing(i ArmSwingIntent) bool             { return b.tryGameplay(i) }

--- a/core/player/item.go
+++ b/core/player/item.go
@@ -23,6 +23,31 @@ const HotbarStart = 36
 // them appear stuck or desynchronised in the client UI.
 const OffhandSlot = 45
 
+const (
+	MaxFireworkExplosions = 7
+	MaxFireworkColors     = 8
+)
+
+// FireworkExplosion is a bounded, comparable representation of one vanilla
+// firework explosion component. Shape uses the vanilla 0-4 shape IDs.
+type FireworkExplosion struct {
+	Shape          uint8
+	Colors         [MaxFireworkColors]int32
+	ColorCount     uint8
+	FadeColors     [MaxFireworkColors]int32
+	FadeColorCount uint8
+	Trail          bool
+	Twinkle        bool
+}
+
+// FireworkData is the canonical minecraft:fireworks component shared by both
+// protocol adapters and the server-side rocket entity.
+type FireworkData struct {
+	Flight         uint8
+	ExplosionCount uint8
+	Explosions     [MaxFireworkExplosions]FireworkExplosion
+}
+
 // ItemStack is a quantity of one item type occupying a single inventory slot.
 // A zero-value ItemStack (or one with Count ≤ 0) represents an empty slot.
 //
@@ -44,6 +69,10 @@ type ItemStack struct {
 	// PotDecorations stores the four side decorations of a decorated-pot item.
 	// An array keeps ItemStack comparable, which is important for inventory diffing.
 	PotDecorations [4]string `json:",omitempty"`
+	// HasFireworks distinguishes a decoded component from an absent one. The
+	// effective vanilla default for a rocket is flight duration one.
+	HasFireworks bool         `json:",omitempty"`
+	Fireworks    FireworkData `json:",omitempty"`
 }
 
 type armorItemStats struct {
@@ -137,7 +166,35 @@ func (s ItemStack) NormalizedPotDecorations() [4]string {
 // SameItem reports whether two stacks may merge without losing components.
 func (s ItemStack) SameItem(other ItemStack) bool {
 	return s.ItemID == other.ItemID && s.Damage == other.Damage && s.Enchantments == other.Enchantments &&
-		s.NormalizedPotDecorations() == other.NormalizedPotDecorations()
+		s.NormalizedPotDecorations() == other.NormalizedPotDecorations() &&
+		s.EffectiveFireworks() == other.EffectiveFireworks()
+}
+
+// EffectiveFireworks returns a validated component. Vanilla rockets without
+// an explicit override inherit flight duration one and no explosions.
+func (s ItemStack) EffectiveFireworks() FireworkData {
+	if s.ItemID != "minecraft:firework_rocket" {
+		return FireworkData{}
+	}
+	data := s.Fireworks
+	if !s.HasFireworks {
+		data.Flight = 1
+	}
+	if data.ExplosionCount > MaxFireworkExplosions {
+		data.ExplosionCount = MaxFireworkExplosions
+	}
+	for index := range int(data.ExplosionCount) {
+		if data.Explosions[index].Shape > 4 {
+			data.Explosions[index].Shape = 0
+		}
+		if data.Explosions[index].ColorCount > MaxFireworkColors {
+			data.Explosions[index].ColorCount = MaxFireworkColors
+		}
+		if data.Explosions[index].FadeColorCount > MaxFireworkColors {
+			data.Explosions[index].FadeColorCount = MaxFireworkColors
+		}
+	}
+	return data
 }
 
 // MaxDurability returns Java Edition's vanilla maximum durability for the

--- a/core/player/player.go
+++ b/core/player/player.go
@@ -506,7 +506,8 @@ func (p *Player) GiveItem(item ItemStack) bool {
 			if add > stackLimit {
 				add = stackLimit
 			}
-			*slot = ItemStack{ItemID: item.ItemID, Count: add, Damage: item.Damage}
+			*slot = item
+			slot.Count = add
 			remaining -= add
 		}
 	}

--- a/core/world/attachment_placement.go
+++ b/core/world/attachment_placement.go
@@ -316,6 +316,21 @@ func isStandingBannerName(name string) bool {
 	return strings.HasSuffix(name, "_banner") && !strings.HasSuffix(name, "_wall_banner")
 }
 func isWallBannerName(name string) bool { return strings.HasSuffix(name, "_wall_banner") }
+
+// PlacementBlockEntityType returns the canonical block-entity type created by
+// placing a sign or banner item.
+func PlacementBlockEntityType(name string) (string, bool) {
+	switch {
+	case isCeilingHangingSignName(name), isWallHangingSignName(name):
+		return "minecraft:hanging_sign", true
+	case isStandingSignName(name), isWallSignName(name):
+		return "minecraft:sign", true
+	case isStandingBannerName(name), isWallBannerName(name):
+		return "minecraft:banner", true
+	default:
+		return "", false
+	}
+}
 func isFloorCoralFan(name string) bool {
 	return strings.HasSuffix(name, "_coral_fan") && !strings.HasSuffix(name, "_coral_wall_fan")
 }

--- a/core/world/attachment_placement_test.go
+++ b/core/world/attachment_placement_test.go
@@ -81,6 +81,19 @@ func TestAttachmentPlacementFloorCeilingAndLantern(t *testing.T) {
 	}
 }
 
+func TestPlacementBlockEntityType(t *testing.T) {
+	for name, want := range map[string]string{
+		"minecraft:oak_sign":         "minecraft:sign",
+		"minecraft:oak_wall_sign":    "minecraft:sign",
+		"minecraft:oak_hanging_sign": "minecraft:hanging_sign",
+		"minecraft:red_wall_banner":  "minecraft:banner",
+	} {
+		if got, ok := PlacementBlockEntityType(name); !ok || got != want {
+			t.Errorf("PlacementBlockEntityType(%q) = %q, %v; want %q", name, got, ok, want)
+		}
+	}
+}
+
 func TestBreakUnsupportedDecorativeAttachments(t *testing.T) {
 	w := attachmentTestWorld(t)
 	stone := Block{Namespace: "minecraft", Name: "stone"}

--- a/core/world/block_physics.go
+++ b/core/world/block_physics.go
@@ -384,7 +384,7 @@ func IsRedstoneLoad(name string) bool {
 		"minecraft:note_block", "minecraft:redstone_lamp",
 		"minecraft:tnt",
 		"minecraft:powered_rail", "minecraft:activator_rail",
-		"minecraft:hopper":
+		"minecraft:hopper", "minecraft:bell":
 		return true
 	}
 	return false

--- a/core/world/decorated_pot_observer_test.go
+++ b/core/world/decorated_pot_observer_test.go
@@ -16,3 +16,19 @@ func TestDecoratedPotDecorationMutationNotifiesObserver(t *testing.T) {
 		t.Fatalf("observed decorations = %#v, want %#v", observed.PotDecorations, want)
 	}
 }
+
+func TestSetBlockEntityNotifiesObserverWithOwnedData(t *testing.T) {
+	w := New(&FlatGenerator{}, nil, false)
+	defer w.Close()
+	var observed BlockEntity
+	w.SetBlockEntityObserver(func(entity BlockEntity) { observed = entity })
+	data := []byte{10, 0}
+	w.SetBlockEntity(4, 65, 2, "minecraft:sign", data)
+	data[0] = 0
+	if observed.Type != "minecraft:sign" || observed.X != 4 || observed.Y != 65 || observed.Z != 2 {
+		t.Fatalf("observer snapshot = %+v", observed)
+	}
+	if len(observed.Data) != 2 || observed.Data[0] != 10 {
+		t.Fatalf("observer data aliases caller: %v", observed.Data)
+	}
+}

--- a/core/world/redstone.go
+++ b/core/world/redstone.go
@@ -646,6 +646,14 @@ func (re *RedstoneEngine) applyPowerState(x, y, z int, name string, block Block,
 		return BlockChange{X: x, Y: y, Z: z, Block: newBlock}, true
 	}
 	switch name {
+	case "minecraft:bell":
+		newBlock := redstoneBlockWith(block, "powered", boolStr(powered))
+		if block.Equal(newBlock) {
+			return BlockChange{}, false
+		}
+		re.world.setBlockNoPhysics(x, y, z, newBlock)
+		return BlockChange{X: x, Y: y, Z: z, Block: newBlock}, true
+
 	case "minecraft:redstone_lamp":
 		var newName string
 		if powered {

--- a/core/world/world.go
+++ b/core/world/world.go
@@ -993,19 +993,22 @@ func (w *World) SetBlockEntity(x, y, z int, blockEntityType string, data []byte)
 
 	w.containerMu.Lock()
 	updated := false
+	var snapshot BlockEntity
 	for index := range c.BlockEntities {
 		entity := &c.BlockEntities[index]
 		if entity.X == x && entity.Y == y && entity.Z == z {
 			entity.Type = blockEntityType
 			entity.Data = append([]byte(nil), data...)
+			snapshot = *entity
 			updated = true
 			break
 		}
 	}
 	if !updated {
-		c.BlockEntities = append(c.BlockEntities, BlockEntity{
+		snapshot = BlockEntity{
 			X: x, Y: y, Z: z, Type: blockEntityType, Data: append([]byte(nil), data...),
-		})
+		}
+		c.BlockEntities = append(c.BlockEntities, snapshot)
 	}
 	w.containerMu.Unlock()
 
@@ -1015,6 +1018,7 @@ func (w *World) SetBlockEntity(x, y, z int, blockEntityType string, data []byte)
 	w.touchChunkLocked(key)
 	w.dirty[key] = struct{}{}
 	w.mu.Unlock()
+	w.notifyBlockEntityObserver(snapshot)
 }
 
 // SetBlock places block at absolute world coordinates (x, y, z).

--- a/docs/vanilla-interaction-parity-audit.md
+++ b/docs/vanilla-interaction-parity-audit.md
@@ -1,0 +1,104 @@
+# Vanilla interaction parity audit
+
+Audit date: 2026-08-30. Comparison baseline: GoCraft `vanilla-parity-fix-v2`,
+Dragonfly v0.11 block/item behaviours, PumpkinMC's bell and firework paths, and
+Java/Bedrock vanilla protocol behaviour. This audit covers interaction and
+gameplay code, not whether an item merely exists in a registry.
+
+## Implemented correctly (inspected subset)
+
+- Shared attachment placement chooses standing/wall signs and banners, hanging
+  sign variants, and torch support states. Bedrock receives its legacy block
+  names and support-facing wall-torch state without changing canonical state.
+- Decorated pots place with canonical sherd data, accept items, spill/drop
+  contents, and use the proper tool-sensitive cracked loot path.
+- Basic water/lava source bucket pickup and placement is present in both entry
+  paths, including full cauldron transfer and creative item semantics.
+- Basic throwable entities (snowballs, eggs, ender pearls, experience bottles,
+  splash potions and wind charges) use canonical entities and server ticking.
+
+## Partially implemented
+
+- Bells now ring from valid player hits, redstone rising edges, and projectile
+  impacts. Animation and bell sound are translated for both editions and scoped
+  to the dimension. Raid resonance/raider glow is not implemented.
+- Firework rockets now launch from block use, preserve supported flight and
+  explosion components, tick, accelerate, explode, damage visible nearby living
+  targets, consume in non-creative modes, and synchronise to both editions.
+  Firework-star crafting components, crossbow-loaded rockets, and Elytra boost
+  remain incomplete; GoCraft has no canonical fall-flying state yet.
+- Doors, trapdoors, fence gates, buttons, levers, pressure plates, repeaters and
+  comparators mutate and propagate their important state. Several Bedrock sound
+  events and projectile activation rules (wooden buttons/plates) are incomplete.
+- Note blocks can be tuned on Bedrock and retain redstone state, but Java tuning,
+  instrument selection, note sound/particle output, and redstone note playback
+  are incomplete.
+- Cauldrons handle basic full bucket transfers. Bottles, dyed leather armour,
+  precipitation/dripstone filling and incremental levels are missing.
+- Composters accept a supported compostable set, advance, mature, and dispense
+  bone meal, but probability/table coverage and feedback need a full data audit.
+- Bee nests/beehives expose honey harvesting, bottles and shears, but bees,
+  anger, smoke pacification and occupants are not modelled.
+- Respawn anchors accept glowstone charges. Nether spawn assignment, explosion
+  outside the Nether and charge consumption on respawn are missing.
+- Campfires place/light/extinguish and cook supported recipes. Four-slot visual
+  item progress, smoke/hay effects, projectile lighting and complete drop rules
+  are incomplete.
+- Candles and cakes support basic placement/stacking/eating/extinguishing.
+  Candle-cake creation, lighting feedback and all cross-edition sounds are not
+  complete.
+- Flower pots place and survive on support, but the full pot/unpot interaction
+  and contents block-entity behaviour is incomplete.
+- Signs and banners now physically place and render on both editions with empty
+  block-entity data. Text editing, wax/dye/glow, banner patterns and loom-to-block
+  component preservation are not implemented.
+- Anvils, grindstones, stonecutters, smithing tables, brewing stands, enchanting
+  tables, looms and cartography tables open and have varying amounts of inventory
+  logic. They do not all implement full costs, XP, recipe/property data, sounds,
+  automation and edition-specific validation.
+- Buckets do not yet cover fish/axolotl/tadpole entities, milk use, waterlogging
+  every supported block, dispensers or all cauldron cases.
+- Shears cover pumpkin carving, beehive harvest and loot-sensitive foliage.
+  Sheep shearing, vines/tripwire and complete durability/sound behaviour remain.
+- Bone meal covers the supported crops and growth helpers, but not every plant,
+  underwater fertilisation, grass feature spreading or all particles.
+- Flint and steel/fire charges ignite common targets and prime TNT. Portal
+  ignition and every special target/feedback path are incomplete.
+- Bows/crossbows/tridents/shields have Java-side draw/load/projectile/blocking
+  logic. Bedrock use-state parity, every enchantment, trident loyalty/riptide,
+  crossbow fireworks and shield disable rules are incomplete.
+- Maps can be created and used in workstation recipes, but terrain tracking,
+  decorations, scale/lock data and live map packets are absent.
+- Boats and minecarts have canonical entities, placement, riding and basic
+  physics. Collision, inventory variants, fluid/rail details and complete
+  cross-edition controls still need work.
+
+## Missing
+
+- Jukebox record insertion/ejection, playback, comparator state and sounds.
+- Lectern book insertion/removal/page state, UI and comparator output.
+- Chiseled bookshelf slot interaction, block-entity inventory and comparator.
+- Item frames/glow item frames and armour stands as placeable entities.
+- Lodestone compass binding and tracked target data.
+- Brush archaeology and suspicious-block progress/loot.
+- Fishing rod hook entity, bobber physics, loot and reel interaction.
+- Functional filled-map rendering and tracking.
+
+## Implemented but wrong / not vanilla
+
+- Java boat block-use currently permits spawning against any surface; vanilla
+  placement must raycast a valid fluid surface and reject obstructed placement.
+- Note blocks silently change Bedrock state and have no canonical play event;
+  tuning without sound/particle output is not vanilla behaviour.
+- Several interaction families still have separate Java and Bedrock mutation
+  functions. They often converge on the same world state, but differences in
+  sounds, validation and item feedback remain observable.
+
+## Priorities after this pass
+
+1. Add a canonical gliding/fall-flying state, then implement Elytra firework boost.
+2. Complete sign editing and banner-pattern component preservation.
+3. Add a shared note-block play event and instrument calculation.
+4. Fix boat raycast placement and finish vehicle collision/inventory behaviour.
+5. Implement jukeboxes, lecterns and chiseled bookshelves using canonical block
+   entities instead of protocol-specific container shortcuts.

--- a/internal/protocoldata/java/1.21.4/play.json
+++ b/internal/protocoldata/java/1.21.4/play.json
@@ -9,6 +9,7 @@
 	"minecraft:animate": 3,
     "minecraft:acknowledge_block_change": 5,
     "minecraft:block_entity_data": 7,
+	"minecraft:block_action": 8,
     "minecraft:block_update": 9,
     "minecraft:chunk_batch_finished": 12,
     "minecraft:chunk_batch_start": 13,

--- a/java/handler/bell.go
+++ b/java/handler/bell.go
@@ -1,0 +1,57 @@
+package handler
+
+import (
+	"GoCraft/core/spatial"
+	"GoCraft/java/protocol"
+	"GoCraft/java/session"
+	javaworld "GoCraft/java/world"
+)
+
+func buildBellRingPackets(position spatial.BlockPos, direction string) []*protocol.Packet {
+	bellID, ok := javaworld.BlockTypeID("minecraft:bell")
+	if !ok {
+		return nil
+	}
+	blockEvent := protocol.NewBuilder(packetIDBlockAction).
+		Long(position.Encode()).
+		Byte(1).
+		Byte(javaBellDirection(direction)).
+		VarInt(bellID).
+		Build()
+	sound := buildSoundAt("minecraft:block.bell.use", soundCategoryBlocks,
+		float64(position.X)+0.5, float64(position.Y)+0.5, float64(position.Z)+0.5, 2, 1)
+	if sound == nil {
+		return []*protocol.Packet{blockEvent}
+	}
+	return []*protocol.Packet{blockEvent, sound}
+}
+
+func javaBellDirection(direction string) byte {
+	switch direction {
+	case "south":
+		return 3
+	case "west":
+		return 4
+	case "east":
+		return 5
+	default:
+		return 2
+	}
+}
+
+// BroadcastBellRing sends the transient bell animation and sound to Java
+// viewers in the bell's dimension. The permanent block state is untouched.
+func BroadcastBellRing(position spatial.BlockPos, direction string, dimension int32, mgr *session.Manager) {
+	if mgr == nil {
+		return
+	}
+	packets := buildBellRingPackets(position, direction)
+	for _, current := range mgr.SnapshotAll() {
+		if current.Player == nil || current.Player.Dimension != dimension {
+			continue
+		}
+		for _, packet := range packets {
+			_ = current.Conn.WritePacket(packet)
+		}
+	}
+}

--- a/java/handler/bell_test.go
+++ b/java/handler/bell_test.go
@@ -1,0 +1,29 @@
+package handler
+
+import (
+	"testing"
+
+	"GoCraft/core/spatial"
+	"GoCraft/java/protocol"
+	javaworld "GoCraft/java/world"
+)
+
+func TestJavaBellBlockEventUsesTransientDirection(t *testing.T) {
+	position := spatial.BlockPos{X: 2, Y: 64, Z: -3}
+	packets := buildBellRingPackets(position, "east")
+	if len(packets) != 2 || packets[0].ID != packetIDBlockAction {
+		t.Fatalf("packets=%v", packets)
+	}
+	r := packets[0].Reader()
+	packed, err := protocol.ReadLong(r)
+	if err != nil || packed != position.Encode() {
+		t.Fatalf("position=%d err=%v, want %d", packed, err, position.Encode())
+	}
+	action, _ := protocol.ReadByte(r)
+	direction, _ := protocol.ReadByte(r)
+	blockID, _ := protocol.ReadVarInt(r)
+	wantBellID, ok := javaworld.BlockTypeID("minecraft:bell")
+	if !ok || action != 1 || direction != 5 || blockID != wantBellID {
+		t.Fatalf("action=%d direction=%d block=%d, want 1/5/%d", action, direction, blockID, wantBellID)
+	}
+}

--- a/java/handler/block.go
+++ b/java/handler/block.go
@@ -21,6 +21,7 @@ import (
 	"GoCraft/core/blockloot"
 	corentity "GoCraft/core/entity"
 	coreexperience "GoCraft/core/experience"
+	coreintent "GoCraft/core/intent"
 	"GoCraft/core/player"
 	coreplugin "GoCraft/core/plugin"
 	"GoCraft/core/spatial"
@@ -76,12 +77,12 @@ const (
 
 // handleBlockPacket dispatches an incoming block-interaction packet.
 // Called from the play loop for packets that need the world and session manager.
-func handleBlockPacket(pkt *protocol.Packet, p *player.Player, w *coreworld.World, mgr *session.Manager, conn *network.ClientConn, nextEntityID func() int32, plugins *coreplugin.Bus) error {
+func handleBlockPacket(pkt *protocol.Packet, p *player.Player, w *coreworld.World, mgr *session.Manager, conn *network.ClientConn, nextEntityID func() int32, plugins *coreplugin.Bus, intents *coreintent.Bus) error {
 	switch pkt.ID {
 	case packetIDPlayerAction:
 		return handlePlayerActionWithContext(pkt, p, w, mgr, conn, nextEntityID, plugins)
 	case packetIDUseItemOn:
-		return handleUseItemOn(pkt, p, w, mgr, conn, nextEntityID)
+		return handleUseItemOnWithIntents(pkt, p, w, mgr, conn, nextEntityID, intents)
 	}
 	return nil
 }
@@ -511,6 +512,10 @@ func blockDropItem(blockName string) (string, int) {
 //	Bool      world_border_hit
 //	VarInt    sequence
 func handleUseItemOn(pkt *protocol.Packet, p *player.Player, w *coreworld.World, mgr *session.Manager, conn *network.ClientConn, nextEntityID func() int32) error {
+	return handleUseItemOnWithIntents(pkt, p, w, mgr, conn, nextEntityID, nil)
+}
+
+func handleUseItemOnWithIntents(pkt *protocol.Packet, p *player.Player, w *coreworld.World, mgr *session.Manager, conn *network.ClientConn, nextEntityID func() int32, intents *coreintent.Bus) error {
 	r := pkt.Reader()
 
 	hand, err := protocol.ReadVarInt(r)
@@ -551,6 +556,22 @@ func handleUseItemOn(pkt *protocol.Packet, p *player.Player, w *coreworld.World,
 	// Tool and seed interactions run before generic block/container handling.
 	targetBlock := w.GetBlock(int(bx), int(by), int(bz))
 	held := p.HeldItem()
+	if hand == 0 && held.ItemID == "minecraft:firework_rocket" &&
+		p.GameMode != player.GameModeSpectator {
+		if intents != nil {
+			intents.PostFireworkUse(coreintent.FireworkUseIntent{
+				PlayerUUID: p.UUID,
+				HotbarSlot: int32(p.HeldSlot),
+				Position: spatial.Vec3{
+					X: float64(bx) + float64(cursorX),
+					Y: float64(by) + float64(cursorY),
+					Z: float64(bz) + float64(cursorZ),
+				},
+			})
+		}
+		sendAcknowledgeBlockChange(mgr, p, seq)
+		return nil
+	}
 	if targetBlock.ResourceLocation() == "minecraft:sweet_berry_bush" &&
 		(held.ItemID != "minecraft:bone_meal" || coreworld.CropAge(targetBlock) >= 3) {
 		if count, changes, harvested := w.HarvestSweetBerryBush(int(bx), int(by), int(bz), rand.Uint64()); harvested {
@@ -586,6 +607,20 @@ func handleUseItemOn(pkt *protocol.Packet, p *player.Player, w *coreworld.World,
 	// Sneaking with an item bypasses block activation so a block can be placed
 	// against doors, containers, workstations, composters, and other UIs.
 	bypassActivation := p.Sneaking && !held.IsEmpty()
+	if !bypassActivation && p.GameMode != player.GameModeSpectator && targetBlock.ResourceLocation() == "minecraft:bell" {
+		if _, valid := coreworld.BellRingDirection(targetBlock, face, cursorY); valid {
+			if intents != nil {
+				intents.PostBellRing(coreintent.BellRingIntent{
+					PlayerUUID: p.UUID,
+					Position:   spatial.BlockPos{X: bx, Y: by, Z: bz},
+					Face:       face,
+					HitY:       cursorY,
+				})
+			}
+			sendAcknowledgeBlockChange(mgr, p, seq)
+			return nil
+		}
+	}
 	if !bypassActivation && toggleTrapdoor(int(bx), int(by), int(bz), targetBlock, w, mgr) {
 		sound := "minecraft:block.wooden_trapdoor.open"
 		if targetBlock.Properties["open"] == "true" {
@@ -1020,6 +1055,9 @@ func handleUseItemOn(pkt *protocol.Packet, p *player.Player, w *coreworld.World,
 		applyBlockChange(px, py, pz, block, w, mgr)
 	default:
 		applyBlockChange(px, py, pz, block, w, mgr)
+	}
+	if blockEntityType, ok := coreworld.PlacementBlockEntityType(block.ResourceLocation()); ok {
+		w.SetBlockEntity(px, py, pz, blockEntityType, []byte{10, 0})
 	}
 	if p.GameMode == player.GameModeSurvival {
 		slot := player.HotbarStart + p.HeldSlot

--- a/java/handler/crafting.go
+++ b/java/handler/crafting.go
@@ -374,6 +374,8 @@ func readPlainSlot(r *bytes.Reader) (player.ItemStack, error) {
 	damage := int32(0)
 	enchantments := ""
 	var potDecorations [4]string
+	var fireworks player.FireworkData
+	hasFireworks := false
 	for i := int32(0); i < added; i++ {
 		componentType, err := protocol.ReadVarInt(r)
 		if err != nil {
@@ -458,6 +460,25 @@ func readPlainSlot(r *bytes.Reader) (player.ItemStack, error) {
 			if _, readErr = protocol.ReadBool(r); readErr != nil {
 				return player.ItemStack{}, readErr
 			}
+		case 56: // fireworks: flight duration and bounded explosion list
+			flight, readErr := protocol.ReadVarInt(r)
+			if readErr != nil || flight < 0 || flight > 255 {
+				return player.ItemStack{}, fmt.Errorf("invalid firework flight %d: %w", flight, readErr)
+			}
+			length, readErr := protocol.ReadVarInt(r)
+			if readErr != nil || length < 0 || length > player.MaxFireworkExplosions {
+				return player.ItemStack{}, fmt.Errorf("invalid firework explosion count %d: %w", length, readErr)
+			}
+			fireworks.Flight = uint8(flight)
+			fireworks.ExplosionCount = uint8(length)
+			for explosionIndex := int32(0); explosionIndex < length; explosionIndex++ {
+				explosion, readErr := readJavaFireworkExplosion(r)
+				if readErr != nil {
+					return player.ItemStack{}, readErr
+				}
+				fireworks.Explosions[explosionIndex] = explosion
+			}
+			hasFireworks = true
 		default:
 			return player.ItemStack{}, fmt.Errorf("unsupported item component %d", componentType)
 		}
@@ -476,7 +497,47 @@ func readPlainSlot(r *bytes.Reader) (player.ItemStack, error) {
 	}
 	return player.ItemStack{
 		ItemID: name, Count: int(count), Damage: int(damage), Enchantments: enchantments, PotDecorations: potDecorations,
+		HasFireworks: hasFireworks, Fireworks: fireworks,
 	}, nil
+}
+
+func readJavaFireworkExplosion(r *bytes.Reader) (player.FireworkExplosion, error) {
+	var explosion player.FireworkExplosion
+	shape, err := protocol.ReadVarInt(r)
+	if err != nil || shape < 0 || shape > 4 {
+		return explosion, fmt.Errorf("invalid firework shape %d: %w", shape, err)
+	}
+	explosion.Shape = uint8(shape)
+	colors, err := protocol.ReadVarInt(r)
+	if err != nil || colors < 0 || colors > player.MaxFireworkColors {
+		return explosion, fmt.Errorf("invalid firework color count %d: %w", colors, err)
+	}
+	explosion.ColorCount = uint8(colors)
+	for index := int32(0); index < colors; index++ {
+		color, readErr := protocol.ReadInt(r)
+		if readErr != nil {
+			return explosion, readErr
+		}
+		explosion.Colors[index] = color
+	}
+	fades, err := protocol.ReadVarInt(r)
+	if err != nil || fades < 0 || fades > player.MaxFireworkColors {
+		return explosion, fmt.Errorf("invalid firework fade count %d: %w", fades, err)
+	}
+	explosion.FadeColorCount = uint8(fades)
+	for index := int32(0); index < fades; index++ {
+		color, readErr := protocol.ReadInt(r)
+		if readErr != nil {
+			return explosion, readErr
+		}
+		explosion.FadeColors[index] = color
+	}
+	explosion.Trail, err = protocol.ReadBool(r)
+	if err != nil {
+		return explosion, err
+	}
+	explosion.Twinkle, err = protocol.ReadBool(r)
+	return explosion, err
 }
 
 func skipNetworkNBT(r *bytes.Reader) error {

--- a/java/handler/firework_test.go
+++ b/java/handler/firework_test.go
@@ -1,0 +1,53 @@
+package handler
+
+import (
+	"bytes"
+	"testing"
+
+	"GoCraft/core/intent"
+	"GoCraft/core/player"
+	"GoCraft/core/spatial"
+	coreworld "GoCraft/core/world"
+	"GoCraft/java/protocol"
+	"GoCraft/java/session"
+)
+
+func TestJavaFireworkComponentRoundTrip(t *testing.T) {
+	stack := player.ItemStack{ItemID: "minecraft:firework_rocket", Count: 3, HasFireworks: true}
+	stack.Fireworks.Flight = 2
+	stack.Fireworks.ExplosionCount = 1
+	stack.Fireworks.Explosions[0] = player.FireworkExplosion{
+		Shape: 2, ColorCount: 2, Colors: [player.MaxFireworkColors]int32{0xb02e26, 0x3c44aa},
+		FadeColorCount: 1, FadeColors: [player.MaxFireworkColors]int32{0xfed83d}, Trail: true, Twinkle: true,
+	}
+	b := protocol.NewBuilder(0)
+	encodeSlot(b, stack)
+	decoded, err := readPlainSlot(bytes.NewReader(b.Build().Data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !decoded.HasFireworks || decoded.EffectiveFireworks() != stack.EffectiveFireworks() || decoded.Count != 3 {
+		t.Fatalf("decoded=%+v, want %+v", decoded, stack)
+	}
+}
+
+func TestJavaFireworkUsePostsCanonicalIntent(t *testing.T) {
+	p := player.New([16]byte{44}, "rocket-user", player.ClientEditionJava)
+	p.HeldSlot = 2
+	p.Inventory[player.HotbarStart+2] = player.ItemStack{ItemID: "minecraft:firework_rocket", Count: 1}
+	w := coreworld.New(&coreworld.FlatGenerator{}, nil, false)
+	defer w.Close()
+	bus := intent.NewBus(1, 4)
+	if err := handleUseItemOnWithIntents(useItemOnPacket(4, 63, -2, 1, 900), p, w, session.NewManager(), nil, nil, bus); err != nil {
+		t.Fatal(err)
+	}
+	drained := bus.Drain()
+	if len(drained.Gameplay) != 1 {
+		t.Fatalf("gameplay intents = %#v", drained.Gameplay)
+	}
+	got, ok := drained.Gameplay[0].(intent.FireworkUseIntent)
+	if !ok || got.PlayerUUID != p.UUID || got.HotbarSlot != 2 ||
+		got.Position != (spatial.Vec3{X: 4.5, Y: 63.5, Z: -1.5}) {
+		t.Fatalf("firework intent = %#v", drained.Gameplay[0])
+	}
+}

--- a/java/handler/inventory.go
+++ b/java/handler/inventory.go
@@ -484,12 +484,16 @@ func encodeSlot(b *protocol.Builder, item player.ItemStack) {
 		if item.ItemID == "minecraft:decorated_pot" {
 			componentCount++
 		}
+		if item.ItemID == "minecraft:firework_rocket" {
+			componentCount++
+		}
 		b.VarInt(int32(item.Count)).
 			VarInt(id).
 			VarInt(componentCount).
 			VarInt(0) // components_to_remove
 		encodeSlotEnchantments(b, enchantments)
 		encodeSlotPotDecorations(b, item)
+		encodeSlotFireworks(b, item)
 		return
 	}
 	damage := item.Damage
@@ -654,5 +658,25 @@ func encodeSlotPotDecorations(b *protocol.Builder, item player.ItemStack) {
 	b.VarInt(61).VarInt(int32(len(decorations)))
 	for _, decoration := range decorations {
 		b.VarInt(javaworld.ItemID(decoration))
+	}
+}
+
+func encodeSlotFireworks(b *protocol.Builder, item player.ItemStack) {
+	if item.ItemID != "minecraft:firework_rocket" {
+		return
+	}
+	data := item.EffectiveFireworks()
+	b.VarInt(56).VarInt(int32(data.Flight)).VarInt(int32(data.ExplosionCount))
+	for index := range int(data.ExplosionCount) {
+		explosion := data.Explosions[index]
+		b.VarInt(int32(explosion.Shape)).VarInt(int32(explosion.ColorCount))
+		for color := range int(explosion.ColorCount) {
+			b.Int(explosion.Colors[color])
+		}
+		b.VarInt(int32(explosion.FadeColorCount))
+		for color := range int(explosion.FadeColorCount) {
+			b.Int(explosion.FadeColors[color])
+		}
+		b.Bool(explosion.Trail).Bool(explosion.Twinkle)
 	}
 }

--- a/java/handler/mob.go
+++ b/java/handler/mob.go
@@ -60,7 +60,7 @@ func buildSpawnMob(e *corentity.Entity) (*protocol.Packet, bool) {
 	data := int32(0)
 	if e.Type == corentity.TypeFallingBlock {
 		data = e.FallingBlockStateID
-	} else if corentity.IsProjectile(e.Type) && e.OwnerEntityID != 0 {
+	} else if corentity.IsProjectile(e.Type) && e.Type != corentity.TypeFireworkRocket && e.OwnerEntityID != 0 {
 		data = e.OwnerEntityID + 1
 	}
 	return protocol.NewBuilder(packetIDSpawnEntity).
@@ -94,6 +94,16 @@ func buildMobMetadata(e *corentity.Entity) *protocol.Packet {
 			VarInt(7) // ItemStack metadata serializer
 		encodeSlot(b, player.ItemStack{
 			ItemID: e.ItemID, Count: e.ItemCount, Damage: e.ItemDamage, PotDecorations: e.ItemPotDecorations,
+		})
+		return b.Byte(0xff).Build()
+	}
+	if e.Type == corentity.TypeFireworkRocket {
+		b := protocol.NewBuilder(packetIDSetEntityData).
+			VarInt(e.EntityID).
+			Byte(8).
+			VarInt(7)
+		encodeSlot(b, player.ItemStack{
+			ItemID: "minecraft:firework_rocket", Count: 1, HasFireworks: true, Fireworks: e.FireworkData,
 		})
 		return b.Byte(0xff).Build()
 	}
@@ -294,6 +304,20 @@ func BroadcastEntityStatus(entityID int32, status byte, mgr *session.Manager) {
 	pkt := buildEntityEvent(entityID, status)
 	for _, s := range mgr.SnapshotAll() {
 		_ = s.Conn.WritePacket(pkt)
+	}
+}
+
+// BroadcastEntityStatusInDimension emits a transient entity event only to
+// viewers of the canonical world that owns the entity.
+func BroadcastEntityStatusInDimension(entityID int32, status byte, mgr *session.Manager, dimension int32) {
+	if mgr == nil {
+		return
+	}
+	pkt := buildEntityEvent(entityID, status)
+	for _, current := range mgr.SnapshotAll() {
+		if current.Player != nil && current.Player.Dimension == dimension {
+			_ = current.Conn.WritePacket(pkt)
+		}
 	}
 }
 
@@ -733,6 +757,19 @@ func DispatchWorldTime(age, dayTime int64, mgr *session.Manager) {
 // The goroutine therefore only reads from immutable []byte packet buffers —
 // it never touches entity fields, so there is no data race with the next tick.
 func DispatchTickBroadcast(moved []*corentity.Entity, hurtEntities []*corentity.Entity, deathIDs, deadIDs []int32, spawned []*corentity.Entity, mgr *session.Manager) {
+	dispatchTickBroadcast(moved, hurtEntities, deathIDs, deadIDs, spawned, mgr, nil)
+}
+
+// DispatchTickBroadcastInDimension keeps entity movement and removal inside
+// the canonical world that owns it.
+func DispatchTickBroadcastInDimension(moved []*corentity.Entity, hurtEntities []*corentity.Entity, deathIDs, deadIDs []int32, spawned []*corentity.Entity, mgr *session.Manager, dimension int32) {
+	dispatchTickBroadcast(moved, hurtEntities, deathIDs, deadIDs, spawned, mgr, &dimension)
+}
+
+func dispatchTickBroadcast(moved []*corentity.Entity, hurtEntities []*corentity.Entity, deathIDs, deadIDs []int32, spawned []*corentity.Entity, mgr *session.Manager, dimension *int32) {
+	if mgr == nil {
+		return
+	}
 	pkts := make([]*protocol.Packet, 0, len(moved)+len(hurtEntities)+len(deathIDs)+len(deadIDs)+len(spawned)*2)
 	for _, e := range spawned {
 		if spawn, ok := buildSpawnMob(e); ok {
@@ -767,6 +804,9 @@ func DispatchTickBroadcast(moved []*corentity.Entity, hurtEntities []*corentity.
 	// cannot stall the simulation tick.
 	go func() {
 		for _, s := range mgr.SnapshotAll() {
+			if dimension != nil && (s.Player == nil || s.Player.Dimension != *dimension) {
+				continue
+			}
 			for _, pkt := range pkts {
 				_ = s.Conn.WritePacket(pkt)
 			}

--- a/java/handler/packets.go
+++ b/java/handler/packets.go
@@ -90,6 +90,7 @@ var (
 	packetIDTeleportEntity         = protocoldata.MustCB("play", "minecraft:entity_position_sync")
 	packetIDMoveVehicleSC          = protocoldata.MustCB("play", "minecraft:move_vehicle")
 	packetIDBlockEntityData        = protocoldata.MustCB("play", "minecraft:block_entity_data")
+	packetIDBlockAction            = protocoldata.MustCB("play", "minecraft:block_action")
 	packetIDBlockUpdate            = protocoldata.MustCB("play", "minecraft:block_update")
 	packetIDAcknowledgeBlockChange = protocoldata.MustCB("play", "minecraft:acknowledge_block_change")
 	packetIDSetContainerContent    = protocoldata.MustCB("play", "minecraft:set_container_content")

--- a/java/handler/play.go
+++ b/java/handler/play.go
@@ -897,7 +897,7 @@ func playLoop(conn *network.ClientConn, p *player.Player, spawnTeleportID int32,
 
 		// Block interaction needs both the world and the session manager.
 		if pkt.ID == packetIDPlayerAction || pkt.ID == packetIDUseItemOn {
-			if err := handleBlockPacket(pkt, p, w, mgr, conn, nextEntityID, plugins); err != nil {
+			if err := handleBlockPacket(pkt, p, w, mgr, conn, nextEntityID, plugins, intentBus); err != nil {
 				slog.Warn("block interaction error", "player", p.Username, "err", err)
 			}
 		}

--- a/java/handler/recipes_test.go
+++ b/java/handler/recipes_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"GoCraft/core/player"
 	"GoCraft/java/protocol"
 )
 
@@ -175,6 +176,29 @@ func skipSlotDisplay(t *testing.T, reader *bytes.Reader) {
 				}
 				for decoration := int32(0); decoration < decorations; decoration++ {
 					_ = mustReadRecipeVarInt(t, reader)
+				}
+			case 56: // fireworks
+				_ = mustReadRecipeVarInt(t, reader) // flight duration
+				explosions := mustReadRecipeVarInt(t, reader)
+				if explosions < 0 || explosions > player.MaxFireworkExplosions {
+					t.Fatalf("invalid firework explosion count %d", explosions)
+				}
+				for explosion := int32(0); explosion < explosions; explosion++ {
+					_ = mustReadRecipeVarInt(t, reader) // shape
+					for colourSet := 0; colourSet < 2; colourSet++ {
+						colours := mustReadRecipeVarInt(t, reader)
+						for colour := int32(0); colour < colours; colour++ {
+							if _, err := protocol.ReadInt(reader); err != nil {
+								t.Fatal(err)
+							}
+						}
+					}
+					if _, err := protocol.ReadBool(reader); err != nil {
+						t.Fatal(err)
+					}
+					if _, err := protocol.ReadBool(reader); err != nil {
+						t.Fatal(err)
+					}
 				}
 			case 13:
 				attributes := mustReadRecipeVarInt(t, reader)

--- a/java/handler/sound.go
+++ b/java/handler/sound.go
@@ -13,6 +13,7 @@ const (
 	soundCategoryBlocks  int32 = 4
 	soundCategoryNeutral int32 = 6
 	soundCategoryPlayers int32 = 7
+	soundCategoryAmbient int32 = 8
 )
 
 // soundHolderID encodes a registry reference in the 1.21.4 Holder format.
@@ -68,6 +69,9 @@ const SoundCategoryPlayers int32 = soundCategoryPlayers
 
 // SoundCategoryNeutral is the sound category for passive and neutral mobs.
 const SoundCategoryNeutral int32 = soundCategoryNeutral
+
+// SoundCategoryAmbient is the category vanilla uses for launched fireworks.
+const SoundCategoryAmbient int32 = soundCategoryAmbient
 
 // BroadcastSoundAt plays a positioned sound event to all connected players.
 func BroadcastSoundAt(mgr *session.Manager, name string, category int32, x, y, z float64, volume, pitch float32) {

--- a/java/world/blocks.go
+++ b/java/world/blocks.go
@@ -23,6 +23,10 @@ import coreworld "GoCraft/core/world"
 // Populated at init time by registry.go from the embedded blocks.json.
 var javaStateIDs map[string]int32
 
+// blockTypeIDs maps block resource locations to registry IDs used by packets
+// such as Block Event. These IDs are distinct from global block-state IDs.
+var blockTypeIDs map[string]int32
+
 // biomeIDs maps canonical biome resource locations to their protocol IDs for
 // Minecraft Java Edition 1.21.4 (protocol 769).
 // Populated at init time by registry.go from the embedded registries.json.
@@ -64,6 +68,12 @@ func StateID(b coreworld.Block) int32 {
 // BlockEntityTypeID resolves a Java 1.21.4 block entity type.
 func BlockEntityTypeID(name string) (int32, bool) {
 	id, ok := blockEntityTypeIDs[name]
+	return id, ok
+}
+
+// BlockTypeID resolves a block's minecraft:block registry ID.
+func BlockTypeID(name string) (int32, bool) {
+	id, ok := blockTypeIDs[name]
 	return id, ok
 }
 func BiomeID(name string) int32 {

--- a/java/world/registry.go
+++ b/java/world/registry.go
@@ -172,6 +172,7 @@ func loadRegistries() {
 	validateVersion(raw, "registries.json")
 
 	itemIDs, itemNames = loadItemRegistry()
+	blockTypeIDs, _ = loadRegistry(raw, "minecraft:block", "registries.json")
 	etMap, _ := loadRegistry(raw, "minecraft:entity_type", "registries.json")
 	entityTypeIDs = etMap
 	// Dynamic biome IDs are assigned by the ordered Registry Data snapshot sent

--- a/server/bedrock_actions.go
+++ b/server/bedrock_actions.go
@@ -23,6 +23,17 @@ func (s *Server) applyBedrockItemAction(p *player.Player, i intent.BlockInteract
 	if held.IsEmpty() {
 		return false
 	}
+	if held.ItemID == "minecraft:firework_rocket" && p.GameMode != player.GameModeSpectator {
+		return s.applyFireworkUse(intent.FireworkUseIntent{
+			PlayerUUID: p.UUID,
+			HotbarSlot: int32(p.HeldSlot),
+			Position: spatial.Vec3{
+				X: float64(i.Position.X) + float64(i.ClickX),
+				Y: float64(i.Position.Y) + float64(i.ClickY),
+				Z: float64(i.Position.Z) + float64(i.ClickZ),
+			},
+		}) != nil
+	}
 	x, y, z := int(i.Position.X), int(i.Position.Y), int(i.Position.Z)
 	name, item := target.ResourceLocation(), held.ItemID
 	if (name == "minecraft:campfire" || name == "minecraft:soul_campfire") && target.Properties["lit"] != "false" {
@@ -573,6 +584,9 @@ func (s *Server) placeBedrockHeldBlock(p *player.Player, i intent.BlockInteractI
 	}
 	if name == "minecraft:decorated_pot" {
 		s.bedrockWorld().SetDecoratedPotDecorations(px, py, pz, held.NormalizedPotDecorations())
+	}
+	if blockEntityType, ok := coreworld.PlacementBlockEntityType(placed.ResourceLocation()); ok {
+		s.bedrockWorld().SetBlockEntity(px, py, pz, blockEntityType, []byte{10, 0})
 	}
 	s.consumeBedrockHeldItem(p, 1)
 	return true

--- a/server/bell.go
+++ b/server/bell.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"GoCraft/core/intent"
+	"GoCraft/core/player"
+	"GoCraft/core/spatial"
+	coreworld "GoCraft/core/world"
+	"GoCraft/java/handler"
+)
+
+func (s *Server) applyBellRing(i intent.BellRingIntent) {
+	p := s.game.GetPlayer(i.PlayerUUID)
+	if p == nil || p.Dead || p.GameMode == player.GameModeSpectator {
+		return
+	}
+	world := s.worldForPlayer(p)
+	if world == nil {
+		return
+	}
+	centre := spatial.Vec3{X: float64(i.Position.X) + 0.5, Y: float64(i.Position.Y) + 0.5, Z: float64(i.Position.Z) + 0.5}
+	if p.Position.Distance(centre) > 6.5 {
+		return
+	}
+	block := world.GetBlock(int(i.Position.X), int(i.Position.Y), int(i.Position.Z))
+	direction, valid := coreworld.BellRingDirection(block, i.Face, i.HitY)
+	if valid {
+		s.ringBell(world, p.Dimension, i.Position, direction)
+	}
+}
+
+func (s *Server) ringBell(world *coreworld.World, dimension int32, position spatial.BlockPos, direction string) {
+	if world == nil || world.GetBlock(int(position.X), int(position.Y), int(position.Z)).ResourceLocation() != "minecraft:bell" {
+		return
+	}
+	handler.BroadcastBellRing(position, direction, dimension, s.sessions)
+	if s.bedrockListener != nil {
+		s.bedrockListener.BroadcastBellRing(dimension, position, direction)
+	}
+	world.EmitVibration(int(position.X), int(position.Y), int(position.Z))
+}

--- a/server/firework.go
+++ b/server/firework.go
@@ -1,0 +1,157 @@
+package server
+
+import (
+	"math"
+
+	corentity "GoCraft/core/entity"
+	"GoCraft/core/intent"
+	"GoCraft/core/player"
+	"GoCraft/core/spatial"
+	coreworld "GoCraft/core/world"
+	"GoCraft/java/handler"
+	"GoCraft/java/session"
+)
+
+func fireworkLifetimeTicks(flight uint8, firstRandom, secondRandom int) int32 {
+	firstRandom = min(max(firstRandom, 0), 5)
+	secondRandom = min(max(secondRandom, 0), 6)
+	return int32((int(flight)+1)*10 + firstRandom + secondRandom)
+}
+
+func (s *Server) applyFireworkUse(i intent.FireworkUseIntent) *corentity.Entity {
+	if s == nil || s.game == nil || i.HotbarSlot < 0 || i.HotbarSlot >= 9 {
+		return nil
+	}
+	p := s.game.GetPlayer(i.PlayerUUID)
+	if p == nil || p.Dead || p.GameMode == player.GameModeSpectator || p.Position.Distance(i.Position) > 6.5 {
+		return nil
+	}
+	slot := player.HotbarStart + int(i.HotbarSlot)
+	stack := p.Inventory[slot]
+	if stack.ItemID != "minecraft:firework_rocket" || stack.Count < 1 {
+		return nil
+	}
+	dimensionWorld := s.worldForPlayer(p)
+	if dimensionWorld == nil {
+		return nil
+	}
+	id := s.game.NextEntityID()
+	rocket := corentity.New(id, newRandomUUID(), corentity.TypeFireworkRocket,
+		i.Position.X, i.Position.Y, i.Position.Z)
+	rocket.OwnerEntityID = p.EntityID
+	rocket.FireworkData = stack.EffectiveFireworks()
+	seed := uint32(id)*1664525 + 1013904223
+	first, second := int(seed%6), int((seed>>8)%7)
+	rocket.FireworkLifetime = fireworkLifetimeTicks(rocket.FireworkData.Flight, first, second)
+	rocket.VX = triangularFireworkVelocity(seed)
+	rocket.VY = 0.05
+	rocket.VZ = triangularFireworkVelocity(seed*1103515245 + 12345)
+	rocket.Pitch = -90
+	dimensionWorld.Entities.Add(rocket)
+
+	if p.GameMode != player.GameModeCreative {
+		p.Inventory[slot].Count--
+		if p.Inventory[slot].Count <= 0 {
+			p.Inventory[slot] = player.ItemStack{}
+		}
+		if p.Edition == player.ClientEditionJava {
+			if target, ok := s.sessions.Get(p.UUID); ok {
+				_ = handler.SyncPlayerInventory(target.Conn, p)
+			}
+		}
+	}
+	handler.BroadcastSpawnMobInDimension(rocket, s.sessions, p.Dimension)
+	handler.BroadcastSoundAtDimension(s.sessions, p.Dimension, "minecraft:entity.firework_rocket.launch",
+		handler.SoundCategoryAmbient, i.Position.X, i.Position.Y, i.Position.Z, 3, 1)
+	if s.bedrockListener != nil {
+		s.bedrockListener.BroadcastFireworkLaunch(p.Dimension, i.Position)
+	}
+	return rocket
+}
+
+func triangularFireworkVelocity(seed uint32) float64 {
+	first := float64(seed&0xffff) / 65535
+	second := float64((seed>>16)&0xffff) / 65535
+	return (first - second) * 0.002297
+}
+
+// tickFireworkRocket advances the canonical entity. It reports true after the
+// explosion event is emitted and the caller should remove the entity.
+func (s *Server) tickFireworkRocket(rocket *corentity.Entity) bool {
+	if rocket == nil || rocket.Type != corentity.TypeFireworkRocket {
+		return false
+	}
+	rocket.VX *= 1.15
+	rocket.VY += 0.04
+	rocket.VZ *= 1.15
+	rocket.Position.X += rocket.VX
+	rocket.Position.Y += rocket.VY
+	rocket.Position.Z += rocket.VZ
+	rocket.FireworkLifeTicks++
+	if rocket.FireworkLifeTicks <= rocket.FireworkLifetime {
+		return false
+	}
+	handler.BroadcastEntityStatusInDimension(rocket.EntityID, 17, s.sessions, s.simulationDimension)
+	if s.bedrockListener != nil {
+		s.bedrockListener.BroadcastFireworkExplosion(s.simulationDimension, rocket.EntityID)
+	}
+	s.damageFireworkTargets(rocket)
+	return true
+}
+
+func (s *Server) damageFireworkTargets(rocket *corentity.Entity) {
+	count := int(rocket.FireworkData.ExplosionCount)
+	if s == nil || s.world == nil || count == 0 {
+		return
+	}
+	force := float64(5 + count*2)
+	s.game.OnlinePlayers(func(p *player.Player) {
+		if p == nil || p.Dimension != s.simulationDimension || p.Dead {
+			return
+		}
+		if damage := fireworkDamage(rocket.Position, p.Position, force); damage > 0 &&
+			s.fireworkHasLineOfSight(rocket.Position, spatial.Vec3{X: p.Position.X, Y: p.Position.Y + 1.62, Z: p.Position.Z}) {
+			target := &session.Session{Player: p}
+			if p.Edition == player.ClientEditionJava {
+				if current, ok := s.sessions.Get(p.UUID); ok {
+					target = current
+				}
+			}
+			handler.DamagePlayer(target, damage, "was blasted by a firework", s.sessions)
+		}
+	})
+	for _, target := range s.world.Entities.Snapshot() {
+		if target == nil || target == rocket || target.Dead || target.MaxHealth <= 0 {
+			continue
+		}
+		if damage := fireworkDamage(rocket.Position, target.Position, force); damage > 0 &&
+			s.fireworkHasLineOfSight(rocket.Position, spatial.Vec3{X: target.Position.X, Y: target.Position.Y + 1, Z: target.Position.Z}) {
+			s.world.QueueEntityDamageFrom(target.EntityID, damage, rocket.Position.X, rocket.Position.Z)
+		}
+	}
+}
+
+func fireworkDamage(source, target spatial.Vec3, force float64) float32 {
+	distance := source.Distance(target)
+	if distance > 5 {
+		return 0
+	}
+	return float32(force * math.Sqrt((5-distance)/5))
+}
+
+func (s *Server) fireworkHasLineOfSight(start, end spatial.Vec3) bool {
+	distance := start.Distance(end)
+	steps := max(2, int(math.Ceil(distance*5)))
+	for step := 1; step < steps; step++ {
+		t := float64(step) / float64(steps)
+		block := s.world.GetBlock(
+			int(math.Floor(start.X+(end.X-start.X)*t)),
+			int(math.Floor(start.Y+(end.Y-start.Y)*t)),
+			int(math.Floor(start.Z+(end.Z-start.Z)*t)),
+		)
+		if coreworld.IsEntitySupportBlock(block.ResourceLocation()) {
+			return false
+		}
+	}
+	return true
+}

--- a/server/firework_test.go
+++ b/server/firework_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"testing"
+
+	corentity "GoCraft/core/entity"
+	"GoCraft/core/game"
+	"GoCraft/core/intent"
+	"GoCraft/core/player"
+	"GoCraft/core/spatial"
+	coreworld "GoCraft/core/world"
+	"GoCraft/java/session"
+)
+
+func newFireworkTestServer(t *testing.T, mode player.GameMode) (*Server, *player.Player) {
+	t.Helper()
+	w := coreworld.New(&coreworld.FlatGenerator{}, nil, false)
+	t.Cleanup(func() { _ = w.Close() })
+	g := game.New()
+	p := player.New([16]byte{52}, "rocket-user", player.ClientEditionBedrock)
+	p.GameMode = mode
+	p.Position = spatial.Vec3{X: 0.5, Y: 64, Z: 0.5}
+	if err := g.AddPlayer(p); err != nil {
+		t.Fatal(err)
+	}
+	return &Server{game: g, world: w, sessions: session.NewManager()}, p
+}
+
+func TestFireworkUseConsumesSurvivalButNotCreative(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		mode player.GameMode
+		want int
+	}{{"survival", player.GameModeSurvival, 1}, {"creative", player.GameModeCreative, 2}} {
+		t.Run(test.name, func(t *testing.T) {
+			s, p := newFireworkTestServer(t, test.mode)
+			data := player.FireworkData{Flight: 2, ExplosionCount: 1}
+			p.Inventory[player.HotbarStart] = player.ItemStack{
+				ItemID: "minecraft:firework_rocket", Count: 2, HasFireworks: true, Fireworks: data,
+			}
+			rocket := s.applyFireworkUse(intent.FireworkUseIntent{
+				PlayerUUID: p.UUID, HotbarSlot: 0, Position: spatial.Vec3{X: 1, Y: 64.5, Z: 0.5},
+			})
+			if rocket == nil || rocket.Type != corentity.TypeFireworkRocket || rocket.FireworkData != data {
+				t.Fatalf("rocket = %+v", rocket)
+			}
+			if got := p.Inventory[player.HotbarStart].Count; got != test.want {
+				t.Fatalf("remaining rockets = %d, want %d", got, test.want)
+			}
+			if _, ok := s.world.Entities.Get(rocket.EntityID); !ok {
+				t.Fatal("canonical rocket was not added to the world")
+			}
+		})
+	}
+}
+
+func TestFireworkLifetimeAndMotion(t *testing.T) {
+	if got := fireworkLifetimeTicks(2, 5, 6); got != 41 {
+		t.Fatalf("lifetime = %d, want 41", got)
+	}
+	s, _ := newFireworkTestServer(t, player.GameModeSurvival)
+	rocket := corentity.New(80, [16]byte{8}, corentity.TypeFireworkRocket, 0, 70, 0)
+	rocket.FireworkLifetime = 1
+	rocket.VX, rocket.VY, rocket.VZ = 0.01, 0.05, -0.01
+	if s.tickFireworkRocket(rocket) {
+		t.Fatal("rocket expired one tick too early")
+	}
+	if rocket.VX != 0.0115 || rocket.VY != 0.09 || rocket.VZ != -0.0115 {
+		t.Fatalf("velocity = %.4f/%.4f/%.4f", rocket.VX, rocket.VY, rocket.VZ)
+	}
+	if !s.tickFireworkRocket(rocket) {
+		t.Fatal("rocket did not expire after its lifetime")
+	}
+}
+
+func TestFireworkExplosionRequiresEffectsAndVisibility(t *testing.T) {
+	if got := fireworkDamage(spatial.Vec3{}, spatial.Vec3{X: 5.1}, 7); got != 0 {
+		t.Fatalf("out-of-range damage = %v", got)
+	}
+	if got := fireworkDamage(spatial.Vec3{}, spatial.Vec3{}, 7); got != 7 {
+		t.Fatalf("point-blank damage = %v, want 7", got)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1008,6 +1008,10 @@ func (s *Server) tickIntents() {
 			s.applyChat(i)
 		case intent.BlockInteractIntent:
 			s.applyBedrockBlockInteract(i)
+		case intent.BellRingIntent:
+			s.applyBellRing(i)
+		case intent.FireworkUseIntent:
+			s.applyFireworkUse(i)
 		case intent.ConsumeFoodIntent:
 			s.applyBedrockConsumeFood(i)
 		case intent.StartUseItemIntent:
@@ -1766,6 +1770,12 @@ func (s *Server) applyBedrockBlockInteract(i intent.BlockInteractIntent) {
 			return
 		}
 		bypassActivation := p.Sneaking && !held.IsEmpty()
+		if !bypassActivation && clicked.ResourceLocation() == "minecraft:bell" {
+			if direction, valid := coreworld.BellRingDirection(clicked, i.Face, i.ClickY); valid {
+				s.ringBell(actionWorld, p.Dimension, i.Position, direction)
+				return
+			}
+		}
 		if !bypassActivation && s.applyBedrockBlockActivation(p, i.Position, clicked) {
 			return
 		}
@@ -2737,6 +2747,15 @@ func (s *Server) tickEntities() {
 			deadIDs = append(deadIDs, e.EntityID)
 			continue
 		}
+		if e.Type == corentity.TypeFireworkRocket {
+			if s.tickFireworkRocket(e) {
+				s.world.Entities.Remove(e.EntityID)
+				deadIDs = append(deadIDs, e.EntityID)
+				continue
+			}
+			moved = append(moved, e)
+			continue
+		}
 
 		// ── Primed TNT fuse countdown ────────────────────────────────────────
 		if e.Type == corentity.TypePrimedTNT {
@@ -2949,7 +2968,7 @@ func (s *Server) tickEntities() {
 	// DispatchTickBroadcast reads entity fields here (tick goroutine, sole
 	// writer) to build immutable packets before spawning the send goroutine.
 	endBcast := s.timings.measure(sectionBroadcast)
-	handler.DispatchTickBroadcast(moved, hurtEntities, deathIDs, deadIDs, spawned, s.sessions)
+	handler.DispatchTickBroadcastInDimension(moved, hurtEntities, deathIDs, deadIDs, spawned, s.sessions, dimensionOverworld)
 	endBcast()
 
 	// Publish time-of-day for handler code (e.g. bed sleep check).
@@ -3367,6 +3386,13 @@ func (s *Server) tickAuxiliaryDimensionItems() {
 				entity.VX *= 0.98
 				entity.VZ *= 0.98
 				moved = append(moved, entity)
+			case entity.Type == corentity.TypeFireworkRocket:
+				if simulation.tickFireworkRocket(entity) {
+					dimensionWorld.Entities.Remove(entity.EntityID)
+					deadIDs = append(deadIDs, entity.EntityID)
+					continue
+				}
+				moved = append(moved, entity)
 			case corentity.IsProjectile(entity.Type):
 				if simulation.tickProjectile(entity) || entity.Position.Y < coreworld.WorldMinY-16 {
 					dimensionWorld.Entities.Remove(entity.EntityID)
@@ -3414,7 +3440,7 @@ func (s *Server) tickAuxiliaryDimensionItems() {
 				}
 			}
 		}
-		handler.DispatchTickBroadcast(moved, hurtEntities, deathIDs, deadIDs, spawned, simulation.sessions)
+		handler.DispatchTickBroadcastInDimension(moved, hurtEntities, deathIDs, deadIDs, spawned, s.sessions, dimension)
 	}
 }
 
@@ -4471,6 +4497,15 @@ func (s *Server) tickProjectile(projectile *corentity.Entity) bool {
 		z := start.Z + (projectile.Position.Z-start.Z)*t
 		block := s.world.GetBlock(int(math.Floor(x)), int(math.Floor(y)), int(math.Floor(z)))
 		if coreworld.IsEntitySupportBlock(block.ResourceLocation()) {
+			if block.ResourceLocation() == "minecraft:bell" {
+				face := coreworld.BellProjectileFace(
+					projectile.Position.X-start.X, projectile.Position.Y-start.Y, projectile.Position.Z-start.Z,
+				)
+				if direction, valid := coreworld.BellRingDirection(block, face, float32(y-math.Floor(y))); valid {
+					position := spatial.BlockPos{X: int32(math.Floor(x)), Y: int32(math.Floor(y)), Z: int32(math.Floor(z))}
+					s.ringBell(s.world, s.simulationDimension, position, direction)
+				}
+			}
 			if projectile.Type == corentity.TypeWindCharge {
 				s.explodeWindCharge(projectile, spatial.Vec3{X: x, Y: y, Z: z})
 			}
@@ -5002,6 +5037,9 @@ func (s *Server) tickBlockPhysicsWorld() {
 			s.activateDropperOrDispenser(s.world, s.simulationDimension, pos[0], pos[1], pos[2], block.ResourceLocation(), &blockChanges)
 		case "minecraft:crafter":
 			s.activateCrafter(s.world, s.simulationDimension, pos[0], pos[1], pos[2])
+		case "minecraft:bell":
+			position := spatial.BlockPos{X: int32(pos[0]), Y: int32(pos[1]), Z: int32(pos[2])}
+			s.ringBell(s.world, s.simulationDimension, position, coreworld.BellFacingDirection(block))
 		case "minecraft:piston", "minecraft:sticky_piston":
 			blockChanges = append(blockChanges, s.world.ApplyPistonPower(pos[0], pos[1], pos[2], true)...)
 		}

--- a/server/sign_banner_placement_test.go
+++ b/server/sign_banner_placement_test.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"testing"
+
+	"GoCraft/core/intent"
+	"GoCraft/core/player"
+	"GoCraft/core/spatial"
+	coreworld "GoCraft/core/world"
+)
+
+func TestBedrockSignsAndBannersCreateCanonicalBlockEntities(t *testing.T) {
+	for _, test := range []struct {
+		item, wantBlock, wantEntity string
+	}{
+		{"minecraft:oak_sign", "minecraft:oak_sign", "minecraft:sign"},
+		{"minecraft:red_banner", "minecraft:red_banner", "minecraft:banner"},
+	} {
+		t.Run(test.item, func(t *testing.T) {
+			s, p := newBedrockActionTestServer(t)
+			s.world.SetBlock(0, 64, 0, coreworld.Block{Namespace: "minecraft", Name: "stone"})
+			p.Inventory[player.HotbarStart] = player.ItemStack{ItemID: test.item, Count: 1}
+			s.applyBedrockBlockInteract(intent.BlockInteractIntent{
+				PlayerUUID: p.UUID, Action: intent.BlockActionUse,
+				Position: spatial.BlockPos{X: 0, Y: 64, Z: 0}, Face: 1, HotbarSlot: 0,
+				ClickX: 0.5, ClickY: 1, ClickZ: 0.5,
+			})
+			if got := s.world.GetBlock(0, 65, 0).ResourceLocation(); got != test.wantBlock {
+				t.Fatalf("placed block = %q, want %q", got, test.wantBlock)
+			}
+			entities := s.world.LoadedBlockEntities()
+			if len(entities) != 1 || entities[0].Type != test.wantEntity {
+				t.Fatalf("block entities = %+v, want one %s", entities, test.wantEntity)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Wall torch / attachment placement**: shared path selects standing/wall signs, hanging sign variants, and torch support states. Bedrock receives legacy block names and correct support-facing wall-torch state without touching canonical world state.
- **Signs and banners**: both editions receive initial block-entity data on placement so clients render immediately without a resync round-trip.
- **Bells**: server-side ringing from player hit, redstone rising edge, and projectile impact. Sound and animation translated for Java and Bedrock, scoped to the dimension. Raid resonance/raider glow not yet implemented.
- **Firework rockets**: launch from block use, flight and explosion components preserved, server ticking, acceleration, explosion damage to nearby living targets, creative-mode item semantics, Java and Bedrock sync. Elytra boost and crossbow-loaded rockets remain incomplete.
- **Parity audit**: `docs/vanilla-interaction-parity-audit.md` documents the full implemented/partial/missing/wrong state as of this pass.

## Test plan

- [ ] `go test ./...` passes with no failures
- [ ] Bell rings on player hit, redstone rising edge, and projectile impact on both editions
- [ ] Firework rocket launches, ticks, explodes, and damages nearby entities
- [ ] Wall torches place with correct facing state on Bedrock
- [ ] Signs and banners render on placement without a resync on both editions
- [ ] Firework creative-mode item not consumed; survival mode item consumed on launch