### PR TITLE
Fix cross-edition lighting and remote teleports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,9 @@ plugins/*
 !plugins/README.md
 
 # Worlds and state written by a running server
-world/
-world_nether/
-world_end/
+/world/
+/world_nether/
+/world_end/
 logs/latest.log
 logs/*.log.gz
 ops.json

--- a/bedrock/remote_player_teleport_test.go
+++ b/bedrock/remote_player_teleport_test.go
@@ -4,19 +4,18 @@ import (
 	"testing"
 
 	"GoCraft/core/spatial"
-	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
 )
 
-func TestBedrockRemotePlayerMoveMode(t *testing.T) {
+func TestBedrockRemotePlayerTeleportUsesActorRespawn(t *testing.T) {
 	origin := spatial.Vec3{X: 10, Y: 64, Z: 10}
 
-	if got := bedrockRemotePlayerMoveMode(origin, spatial.Vec3{X: 17.9, Y: 64, Z: 10}); got != byte(packet.MoveModeNormal) {
-		t.Fatalf("small movement should stay normal, got mode %d", got)
+	if bedrockRemotePlayerNeedsRespawn(origin, spatial.Vec3{X: 17.9, Y: 64, Z: 10}) {
+		t.Fatal("small movement should stay on the normal movement path")
 	}
-	if got := bedrockRemotePlayerMoveMode(origin, spatial.Vec3{X: 18.1, Y: 64, Z: 10}); got != byte(packet.MoveModeTeleport) {
-		t.Fatalf("large horizontal jump should use teleport mode, got mode %d", got)
+	if !bedrockRemotePlayerNeedsRespawn(origin, spatial.Vec3{X: 18.1, Y: 64, Z: 10}) {
+		t.Fatal("large horizontal jump should respawn the remote actor")
 	}
-	if got := bedrockRemotePlayerMoveMode(origin, spatial.Vec3{X: 10, Y: 72.1, Z: 10}); got != byte(packet.MoveModeTeleport) {
-		t.Fatalf("large vertical jump should use teleport mode, got mode %d", got)
+	if !bedrockRemotePlayerNeedsRespawn(origin, spatial.Vec3{X: 10, Y: 72.1, Z: 10}) {
+		t.Fatal("large vertical jump should respawn the remote actor")
 	}
 }

--- a/bedrock/sync.go
+++ b/bedrock/sync.go
@@ -314,16 +314,26 @@ func (l *Listener) syncPlayers(viewer *bedrockSession, players []*player.Player,
 			_ = viewer.conn.WritePacket(&packet.ActorEvent{EntityRuntimeID: bedrockRemoteRuntimeID(p.EntityID), EventType: packet.ActorEventDeath})
 		}
 		if p.UUID != viewer.uuid && (previous.position != p.Position || previous.rotation != p.Rotation) {
-			_ = viewer.conn.WritePacket(&packet.MovePlayer{
-				EntityRuntimeID: bedrockRemoteRuntimeID(p.EntityID),
-				Position:        playerNetworkPosition(p.Position),
-				Pitch:           p.Rotation.Pitch,
-				Yaw:             p.Rotation.Yaw,
-				HeadYaw:         p.Rotation.Yaw,
-				Mode:            bedrockRemotePlayerMoveMode(previous.position, p.Position),
-				OnGround:        p.OnGround,
-				Tick:            tick,
-			})
+			if bedrockRemotePlayerNeedsRespawn(previous.position, p.Position) {
+				_ = viewer.conn.WritePacket(&packet.RemoveActor{EntityUniqueID: int64(bedrockRemoteRuntimeID(p.EntityID))})
+				platform := viewer.buildPlatform
+				if targetSession := bedrockByUUID[p.UUID]; targetSession != nil {
+					platform = targetSession.buildPlatform
+				}
+				_ = viewer.conn.WritePacket(buildAddBedrockPlayer(p, platform))
+				l.sendPlayerEquipment(viewer, p)
+			} else {
+				_ = viewer.conn.WritePacket(&packet.MovePlayer{
+					EntityRuntimeID: bedrockRemoteRuntimeID(p.EntityID),
+					Position:        playerNetworkPosition(p.Position),
+					Pitch:           p.Rotation.Pitch,
+					Yaw:             p.Rotation.Yaw,
+					HeadYaw:         p.Rotation.Yaw,
+					Mode:            packet.MoveModeNormal,
+					OnGround:        p.OnGround,
+					Tick:            tick,
+				})
+			}
 		}
 		if p.UUID != viewer.uuid && (previous.inventory != p.Inventory || previous.heldSlot != p.HeldSlot) {
 			l.sendPlayerEquipment(viewer, p)
@@ -409,18 +419,14 @@ func bedrockPlayerInView(viewer, target *player.Player) bool {
 		dz >= -bedrockChunkRadius && dz <= bedrockChunkRadius
 }
 
-// bedrockRemotePlayerMoveMode keeps ordinary walking/sprinting smooth, but
-// marks teleport-sized canonical jumps explicitly. Bedrock clients may discard
-// a huge MoveModeNormal delta for a remote actor, leaving a Java player stale or
-// invisible after /tp until that actor is respawned.
-func bedrockRemotePlayerMoveMode(previous, current spatial.Vec3) byte {
+// bedrockRemotePlayerNeedsRespawn separates smooth movement from an
+// authoritative teleport. Re-spawning a remote actor avoids routing command
+// teleports through the local-player correction path used by MoveModeTeleport.
+func bedrockRemotePlayerNeedsRespawn(previous, current spatial.Vec3) bool {
 	const maxNormalDelta = 8.0
-	if math.Abs(current.X-previous.X) > maxNormalDelta ||
+	return math.Abs(current.X-previous.X) > maxNormalDelta ||
 		math.Abs(current.Y-previous.Y) > maxNormalDelta ||
-		math.Abs(current.Z-previous.Z) > maxNormalDelta {
-		return byte(packet.MoveModeTeleport)
-	}
-	return byte(packet.MoveModeNormal)
+		math.Abs(current.Z-previous.Z) > maxNormalDelta
 }
 
 func entityInView(viewer *player.Player, entity *corentity.Entity) bool {

--- a/core/blockloot/loot_test.go
+++ b/core/blockloot/loot_test.go
@@ -171,6 +171,19 @@ func TestBlockExperienceRequiresToolAndRejectsSilkTouch(t *testing.T) {
 	}
 }
 
+func TestRawMetalOresDoNotDropVanillaExperience(t *testing.T) {
+	for _, name := range []string{"iron_ore", "deepslate_iron_ore", "copper_ore", "deepslate_copper_ore"} {
+		ctx := Context{
+			Block:  block(name),
+			Tool:   player.ItemStack{ItemID: "minecraft:iron_pickaxe", Count: 1},
+			Random: rand.New(rand.NewSource(1)),
+		}
+		if got := Experience(ctx); got != 0 {
+			t.Errorf("%s XP = %d, want vanilla value 0", name, got)
+		}
+	}
+}
+
 func TestDoublePlantChecksOtherHalf(t *testing.T) {
 	lower := block("large_fern", map[string]string{"half": "lower"})
 	got := Drops(Context{

--- a/core/world/decorated_pot_observer_test.go
+++ b/core/world/decorated_pot_observer_test.go
@@ -32,3 +32,17 @@ func TestSetBlockEntityNotifiesObserverWithOwnedData(t *testing.T) {
 		t.Fatalf("observer data aliases caller: %v", observed.Data)
 	}
 }
+
+func TestBlockObserverReceivesPreviousState(t *testing.T) {
+	w := New(&FlatGenerator{}, nil, false)
+	defer w.Close()
+	stone := Block{Namespace: "minecraft", Name: "stone"}
+	torch := Block{Namespace: "minecraft", Name: "torch"}
+	w.SetBlock(1, 64, 1, stone)
+	var observed BlockChange
+	w.SetBlockObserver(func(change BlockChange) { observed = change })
+	w.SetBlock(1, 64, 1, torch)
+	if !observed.Previous.Equal(stone) || !observed.Block.Equal(torch) {
+		t.Fatalf("observer states = previous %s current %s", observed.Previous.ResourceLocation(), observed.Block.ResourceLocation())
+	}
+}

--- a/core/world/world.go
+++ b/core/world/world.go
@@ -95,6 +95,19 @@ type World struct {
 	spawnedVillageGuards map[[2]int]struct{}
 }
 
+// ChunkIfLoaded returns a cached chunk without loading or generating terrain.
+// Network-side derived data such as light updates use this to avoid expanding
+// the world merely because a mutation occurred near a chunk border.
+func (w *World) ChunkIfLoaded(cx, cz int32) (*Chunk, bool) {
+	if w == nil {
+		return nil, false
+	}
+	w.mu.RLock()
+	chunk, ok := w.chunks[[2]int32{cx, cz}]
+	w.mu.RUnlock()
+	return chunk, ok
+}
+
 // SetBlockObserver installs an adapter-neutral notification invoked after each
 // canonical block mutation. It lets secondary protocol adapters mirror Java,
 // physics, redstone, and command changes without importing networking into core.
@@ -104,12 +117,12 @@ func (w *World) SetBlockObserver(observer func(BlockChange)) {
 	w.blockObserverMu.Unlock()
 }
 
-func (w *World) notifyBlockObserver(x, y, z int, block Block) {
+func (w *World) notifyBlockObserver(x, y, z int, previous, block Block) {
 	w.blockObserverMu.RLock()
 	observer := w.blockObserver
 	w.blockObserverMu.RUnlock()
 	if observer != nil {
-		observer(BlockChange{X: x, Y: y, Z: z, Block: block})
+		observer(BlockChange{X: x, Y: y, Z: z, Previous: previous, Block: block})
 	}
 }
 
@@ -730,8 +743,9 @@ func IsEntitySupportBlock(name string) bool {
 
 // BlockChange describes a canonical world mutation that adapters can broadcast.
 type BlockChange struct {
-	X, Y, Z int
-	Block   Block
+	X, Y, Z  int
+	Previous Block
+	Block    Block
 }
 
 // TickFarmland applies vanilla hydration: water within four horizontal blocks
@@ -1071,7 +1085,7 @@ func (w *World) SetBlock(x, y, z int, block Block) {
 	// Schedule physics updates for affected neighbours.
 	// worldAge 0 = "fire next tick" (drainDue uses <= comparison).
 	w.scheduleBlockNeighborUpdates(x, y, z, oldBlock, block)
-	w.notifyBlockObserver(x, y, z, block)
+	w.notifyBlockObserver(x, y, z, oldBlock, block)
 	if !oldBlock.Equal(block) {
 		w.triggerObservers(x, y, z)
 	}
@@ -1122,7 +1136,7 @@ func (w *World) setBlockNoPhysics(x, y, z int, block Block) {
 	w.dirty[key] = struct{}{}
 	w.trimChunksLocked()
 	w.mu.Unlock()
-	w.notifyBlockObserver(x, y, z, block)
+	w.notifyBlockObserver(x, y, z, oldBlock, block)
 	if !oldBlock.Equal(block) {
 		w.triggerObservers(x, y, z)
 	}

--- a/internal/protocoldata/java/1.21.4/play.json
+++ b/internal/protocoldata/java/1.21.4/play.json
@@ -20,6 +20,7 @@
     "minecraft:game_event": 35,
     "minecraft:keep_alive": 39,
     "minecraft:level_chunk_with_light": 40,
+    "minecraft:update_light": 43,
     "minecraft:disconnect": 29,
 	"minecraft:entity_event": 31,
     "minecraft:death_combat_event": 62,

--- a/java/handler/light.go
+++ b/java/handler/light.go
@@ -1,0 +1,44 @@
+package handler
+
+import (
+	"math"
+
+	coreworld "GoCraft/core/world"
+	"GoCraft/java/session"
+	javaworld "GoCraft/java/world"
+)
+
+// BroadcastBlockLightUpdatesInDimension rebuilds the at-most-nine chunks whose
+// block light may be affected by one canonical mutation. The update is scoped
+// to Java viewers of the same dimension; Bedrock derives light client-side.
+func BroadcastBlockLightUpdatesInDimension(world *coreworld.World, change coreworld.BlockChange, mgr *session.Manager, dimension int32) {
+	if world == nil || mgr == nil || !javaworld.BlockLightChanged(change.Previous, change.Block) {
+		return
+	}
+	viewers := make([]*session.Session, 0)
+	for _, current := range mgr.SnapshotAll() {
+		if current != nil && current.Conn != nil && current.Player != nil && current.Player.Dimension == dimension {
+			viewers = append(viewers, current)
+		}
+	}
+	if len(viewers) == 0 {
+		return
+	}
+	cx := int32(math.Floor(float64(change.X) / coreworld.SectionSize))
+	cz := int32(math.Floor(float64(change.Z) / coreworld.SectionSize))
+	for dz := int32(-1); dz <= 1; dz++ {
+		for dx := int32(-1); dx <= 1; dx++ {
+			chunk, loaded := world.ChunkIfLoaded(cx+dx, cz+dz)
+			if !loaded {
+				continue
+			}
+			packet := javaworld.BuildBlockLightUpdate(world, chunk)
+			if packet == nil {
+				continue
+			}
+			for _, viewer := range viewers {
+				_ = viewer.Conn.WritePacket(packet)
+			}
+		}
+	}
+}

--- a/java/handler/play.go
+++ b/java/handler/play.go
@@ -614,7 +614,7 @@ func playLoop(conn *network.ClientConn, p *player.Player, spawnTeleportID int32,
 	}
 	for _, key := range initialKeys {
 		c := w.Chunk(key[0], key[1])
-		if err := sender.SendChunk(conn, c); err != nil {
+		if err := sender.SendChunkFromWorld(conn, w, c); err != nil {
 			return fmt.Errorf("play loop: initial chunk (%d,%d): %w", key[0], key[1], err)
 		}
 		sentChunks[key] = struct{}{}
@@ -1081,7 +1081,7 @@ func sendChunkKeys(
 		return fmt.Errorf(`starting chunk batch: %w`, err)
 	}
 	for _, key := range keys {
-		if err := sender.SendChunk(conn, w.Chunk(key[0], key[1])); err != nil {
+		if err := sender.SendChunkFromWorld(conn, w, w.Chunk(key[0], key[1])); err != nil {
 			return fmt.Errorf(`chunk (%d,%d): %w`, key[0], key[1], err)
 		}
 		sent[key] = struct{}{}
@@ -1120,7 +1120,7 @@ func updateChunkView(
 		}
 		for _, key := range newKeys {
 			c := w.Chunk(key[0], key[1])
-			if err := sender.SendChunk(conn, c); err != nil {
+			if err := sender.SendChunkFromWorld(conn, w, c); err != nil {
 				return fmt.Errorf("chunk (%d,%d): %w", key[0], key[1], err)
 			}
 			sent[key] = struct{}{}

--- a/java/handler/status_icon_test.go
+++ b/java/handler/status_icon_test.go
@@ -25,6 +25,18 @@ func TestLoadServerIconUsesEmbeddedDefault(t *testing.T) {
 	}
 }
 
+func TestLoadServerIconFallsBackWhenConfiguredFileIsMissing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing-server-icon.png")
+	dataURI, err := LoadServerIcon(path)
+	if err != nil {
+		t.Fatalf("LoadServerIcon: %v", err)
+	}
+	icon := decodeStatusIcon(t, dataURI)
+	if icon.Bounds().Dx() != 64 || icon.Bounds().Dy() != 64 {
+		t.Fatalf("icon dimensions = %v, want 64x64", icon.Bounds())
+	}
+}
+
 func TestLoadServerIconResizesConfiguredPNG(t *testing.T) {
 	source := image.NewNRGBA(image.Rect(0, 0, 96, 48))
 	for y := range 48 {

--- a/java/world/block_light.go
+++ b/java/world/block_light.go
@@ -1,0 +1,69 @@
+package world
+
+import (
+	"strings"
+
+	coreworld "GoCraft/core/world"
+)
+
+func blockLightPasses(block coreworld.Block) bool {
+	return isSkyTransparent(block.ResourceLocation()) || blockLightEmission(block) != 0
+}
+
+// BlockLightChanged reports whether a canonical mutation can alter propagated
+// light and therefore requires Java light-section updates.
+func BlockLightChanged(previous, current coreworld.Block) bool {
+	return blockLightEmission(previous) != blockLightEmission(current) ||
+		blockLightPasses(previous) != blockLightPasses(current)
+}
+
+func blockLightEmission(block coreworld.Block) byte {
+	name := block.ResourceLocation()
+	switch name {
+	case "minecraft:torch", "minecraft:wall_torch":
+		return 14
+	case "minecraft:soul_torch", "minecraft:soul_wall_torch", "minecraft:soul_lantern", "minecraft:soul_fire":
+		return 10
+	case "minecraft:glowstone", "minecraft:sea_lantern", "minecraft:shroomlight", "minecraft:jack_o_lantern",
+		"minecraft:lantern", "minecraft:end_rod", "minecraft:beacon", "minecraft:fire", "minecraft:lava":
+		return 15
+	case "minecraft:magma_block":
+		return 3
+	case "minecraft:glow_lichen":
+		return 7
+	case "minecraft:redstone_ore", "minecraft:deepslate_redstone_ore":
+		if block.Properties["lit"] == "true" {
+			return 9
+		}
+	case "minecraft:redstone_torch", "minecraft:redstone_wall_torch":
+		if block.Properties["lit"] != "false" {
+			return 7
+		}
+	case "minecraft:furnace", "minecraft:blast_furnace", "minecraft:smoker":
+		if block.Properties["lit"] == "true" {
+			return 13
+		}
+	case "minecraft:campfire":
+		if block.Properties["lit"] == "true" {
+			return 15
+		}
+	case "minecraft:soul_campfire":
+		if block.Properties["lit"] == "true" {
+			return 10
+		}
+	}
+	if (name == "minecraft:candle" || name == "minecraft:candle_cake" ||
+		strings.HasSuffix(name, "_candle") || strings.HasSuffix(name, "_candle_cake")) &&
+		block.Properties["lit"] == "true" {
+		count := 1
+		if value := block.Properties["candles"]; value == "2" {
+			count = 2
+		} else if value == "3" {
+			count = 3
+		} else if value == "4" {
+			count = 4
+		}
+		return byte(count * 3)
+	}
+	return 0
+}

--- a/java/world/block_light_packet_test.go
+++ b/java/world/block_light_packet_test.go
@@ -1,0 +1,69 @@
+package world
+
+import (
+	"testing"
+
+	coreworld "GoCraft/core/world"
+	"GoCraft/java/protocol"
+)
+
+func TestBuildBlockLightUpdateEncodesJavaLightPayload(t *testing.T) {
+	world := coreworld.New(&coreworld.FlatGenerator{}, nil, false)
+	defer world.Close()
+	world.SetBlock(8, 64, 8, coreworld.Block{Namespace: "minecraft", Name: "torch"})
+	packet := BuildBlockLightUpdate(world, world.Chunk(0, 0))
+	if packet == nil || packet.ID != packetIDUpdateLight {
+		t.Fatalf("packet = %+v, want Java update_light ID %d", packet, packetIDUpdateLight)
+	}
+
+	reader := packet.Reader()
+	for _, field := range []string{"chunk x", "chunk z"} {
+		if _, err := protocol.ReadVarInt(reader); err != nil {
+			t.Fatalf("read %s: %v", field, err)
+		}
+	}
+	if count := readLightBitSet(t, reader); count != 0 {
+		t.Fatalf("sky light mask longs = %d, want 0", count)
+	}
+	if count := readLightBitSet(t, reader); count != 1 {
+		t.Fatalf("block light mask longs = %d, want 1", count)
+	}
+	if count := readLightBitSet(t, reader); count != 0 {
+		t.Fatalf("empty sky light mask longs = %d, want 0", count)
+	}
+	if count := readLightBitSet(t, reader); count != 1 {
+		t.Fatalf("empty block light mask longs = %d, want 1", count)
+	}
+	if count, err := protocol.ReadVarInt(reader); err != nil || count != 0 {
+		t.Fatalf("sky array count = %d, err=%v, want 0", count, err)
+	}
+	blockArrays, err := protocol.ReadVarInt(reader)
+	if err != nil || blockArrays < 1 {
+		t.Fatalf("block array count = %d, err=%v, want at least 1", blockArrays, err)
+	}
+	for index := int32(0); index < blockArrays; index++ {
+		light, readErr := protocol.ReadByteArray(reader)
+		if readErr != nil || len(light) != 2048 {
+			t.Fatalf("block array %d length = %d, err=%v, want 2048", index, len(light), readErr)
+		}
+	}
+	if reader.Len() != 0 {
+		t.Fatalf("update_light has %d trailing bytes", reader.Len())
+	}
+}
+
+func readLightBitSet(t *testing.T, reader interface {
+	Read([]byte) (int, error)
+}) int32 {
+	t.Helper()
+	count, err := protocol.ReadVarInt(reader)
+	if err != nil {
+		t.Fatalf("read light bit-set length: %v", err)
+	}
+	for index := int32(0); index < count; index++ {
+		if _, err := protocol.ReadLong(reader); err != nil {
+			t.Fatalf("read light bit-set long %d: %v", index, err)
+		}
+	}
+	return count
+}

--- a/java/world/block_light_propagation.go
+++ b/java/world/block_light_propagation.go
@@ -1,0 +1,35 @@
+package world
+
+import coreworld "GoCraft/core/world"
+
+func computeBlockLightRegion(region blockLightRegion) []byte {
+	levels := make([]byte, coreworld.SectionCount*coreworld.SectionSize*blockLightRegionWidth*blockLightRegionWidth)
+	queue := seedBlockLightRegion(region, levels)
+	const layerSize = blockLightRegionWidth * blockLightRegionWidth
+	for head := 0; head < len(queue); head++ {
+		index := queue[head]
+		level := levels[index]
+		if level <= 1 {
+			continue
+		}
+		yOffset := index / layerSize
+		rem := index % layerSize
+		z, x := rem/blockLightRegionWidth, rem%blockLightRegionWidth
+		worldY := coreworld.WorldMinY + yOffset
+		for _, delta := range [6][3]int{{-1, 0, 0}, {1, 0, 0}, {0, -1, 0}, {0, 1, 0}, {0, 0, -1}, {0, 0, 1}} {
+			nx, ny, nz := x+delta[0], worldY+delta[1], z+delta[2]
+			if nx < 0 || nx >= blockLightRegionWidth || nz < 0 || nz >= blockLightRegionWidth ||
+				ny < coreworld.WorldMinY || ny > coreworld.WorldMaxY {
+				continue
+			}
+			neighbor := blockLightRegionIndex(nx, ny, nz)
+			next := level - 1
+			if levels[neighbor] >= next || !blockLightPasses(region.blockAt(nx, ny, nz)) {
+				continue
+			}
+			levels[neighbor] = next
+			queue = append(queue, neighbor)
+		}
+	}
+	return levels
+}

--- a/java/world/block_light_region.go
+++ b/java/world/block_light_region.go
@@ -1,0 +1,48 @@
+package world
+
+import coreworld "GoCraft/core/world"
+
+const blockLightRegionWidth = coreworld.SectionSize * 3
+
+type blockLightRegion struct {
+	chunks [3][3]*coreworld.Chunk
+}
+
+func localBlockLightRegion(chunk *coreworld.Chunk) blockLightRegion {
+	var region blockLightRegion
+	region.chunks[1][1] = chunk
+	return region
+}
+
+func worldBlockLightRegion(world *coreworld.World, chunk *coreworld.Chunk) blockLightRegion {
+	region := localBlockLightRegion(chunk)
+	if world == nil || chunk == nil {
+		return region
+	}
+	for dz := -1; dz <= 1; dz++ {
+		for dx := -1; dx <= 1; dx++ {
+			if dx != 0 || dz != 0 {
+				region.chunks[dz+1][dx+1], _ = world.ChunkIfLoaded(chunk.X+int32(dx), chunk.Z+int32(dz))
+			}
+		}
+	}
+	return region
+}
+
+func (r blockLightRegion) blockAt(x, worldY, z int) coreworld.Block {
+	if x < 0 || x >= blockLightRegionWidth || z < 0 || z >= blockLightRegionWidth ||
+		worldY < coreworld.WorldMinY || worldY > coreworld.WorldMaxY {
+		return coreworld.Air
+	}
+	chunk := r.chunks[z/coreworld.SectionSize][x/coreworld.SectionSize]
+	if chunk == nil {
+		// Unknown chunk boundaries are opaque so light cannot leak out and back.
+		return coreworld.Block{Namespace: "minecraft", Name: "bedrock"}
+	}
+	sectionIndex := (worldY - coreworld.WorldMinY) / coreworld.SectionSize
+	return chunk.Sections[sectionIndex].At(x&15, (worldY-coreworld.WorldMinY)&15, z&15)
+}
+
+func blockLightRegionIndex(x, worldY, z int) int {
+	return (worldY-coreworld.WorldMinY)*blockLightRegionWidth*blockLightRegionWidth + z*blockLightRegionWidth + x
+}

--- a/java/world/block_light_sections.go
+++ b/java/world/block_light_sections.go
@@ -1,0 +1,36 @@
+package world
+
+import coreworld "GoCraft/core/world"
+
+func buildBlockLight(region blockLightRegion) (mask, emptyMask int64, arrays [][]byte) {
+	levels := computeBlockLightRegion(region)
+	emptyMask = 1 | int64(1)<<25
+	for sectionIndex := 0; sectionIndex < coreworld.SectionCount; sectionIndex++ {
+		light := acquireSkyLightPage()
+		nonZero := false
+		for localIndex := 0; localIndex < 4096; localIndex++ {
+			x := coreworld.SectionSize + (localIndex & 15)
+			z := coreworld.SectionSize + ((localIndex >> 4) & 15)
+			worldY := coreworld.SectionMinY(sectionIndex) + localIndex/256
+			level := levels[blockLightRegionIndex(x, worldY, z)]
+			if level == 0 {
+				continue
+			}
+			if localIndex&1 == 0 {
+				light[localIndex>>1] |= level
+			} else {
+				light[localIndex>>1] |= level << 4
+			}
+			nonZero = true
+		}
+		bit := int64(1) << (sectionIndex + 1)
+		if nonZero {
+			mask |= bit
+			arrays = append(arrays, light)
+		} else {
+			emptyMask |= bit
+			releaseSkyLightPage(light)
+		}
+	}
+	return mask, emptyMask, arrays
+}

--- a/java/world/block_light_seed.go
+++ b/java/world/block_light_seed.go
@@ -1,0 +1,44 @@
+package world
+
+import coreworld "GoCraft/core/world"
+
+func seedBlockLightRegion(region blockLightRegion, levels []byte) []int {
+	queue := make([]int, 0, 4096)
+	for chunkZ, row := range region.chunks {
+		for chunkX, chunk := range row {
+			if chunk == nil {
+				continue
+			}
+			for sectionIndex, section := range chunk.Sections {
+				if section == nil || section.NonAir == 0 {
+					continue
+				}
+				palette := section.BlockPalette()
+				emission := make([]byte, len(palette))
+				hasEmitter := false
+				for index, block := range palette {
+					emission[index] = blockLightEmission(block)
+					hasEmitter = hasEmitter || emission[index] != 0
+				}
+				if !hasEmitter {
+					continue
+				}
+				for localIndex, paletteIndex := range section.BlockData() {
+					level := emission[paletteIndex]
+					if level == 0 {
+						continue
+					}
+					x := chunkX*16 + (localIndex & 15)
+					z := chunkZ*16 + ((localIndex >> 4) & 15)
+					worldY := coreworld.SectionMinY(sectionIndex) + localIndex/256
+					index := blockLightRegionIndex(x, worldY, z)
+					if levels[index] < level {
+						levels[index] = level
+						queue = append(queue, index)
+					}
+				}
+			}
+		}
+	}
+	return queue
+}

--- a/java/world/block_light_test.go
+++ b/java/world/block_light_test.go
@@ -1,0 +1,57 @@
+package world
+
+import (
+	"testing"
+
+	coreworld "GoCraft/core/world"
+)
+
+func TestTorchBlockLightPropagatesInsideChunk(t *testing.T) {
+	chunk := &coreworld.Chunk{X: 0, Z: 0}
+	sectionIndex := (64 - coreworld.WorldMinY) / 16
+	chunk.Sections[sectionIndex] = coreworld.NewSection()
+	chunk.Sections[sectionIndex].Set(8, 0, 8, coreworld.Block{Namespace: "minecraft", Name: "torch"})
+	levels := computeBlockLightRegion(localBlockLightRegion(chunk))
+
+	if got := levels[blockLightRegionIndex(24, 64, 24)]; got != 14 {
+		t.Fatalf("torch level = %d, want 14", got)
+	}
+	if got := levels[blockLightRegionIndex(25, 64, 24)]; got != 13 {
+		t.Fatalf("adjacent level = %d, want 13", got)
+	}
+}
+
+func TestTorchBlockLightCrossesChunkBorder(t *testing.T) {
+	world := coreworld.New(&coreworld.FlatGenerator{}, nil, false)
+	defer world.Close()
+	world.SetBlock(15, 64, 8, coreworld.Block{Namespace: "minecraft", Name: "torch"})
+	target := world.Chunk(1, 0)
+	levels := computeBlockLightRegion(worldBlockLightRegion(world, target))
+
+	if got := levels[blockLightRegionIndex(16, 64, 24)]; got != 13 {
+		t.Fatalf("light across chunk border = %d, want 13", got)
+	}
+}
+
+func TestBlockLightMasksContainTorchSection(t *testing.T) {
+	chunk := &coreworld.Chunk{}
+	sectionIndex := (64 - coreworld.WorldMinY) / 16
+	chunk.Sections[sectionIndex] = coreworld.NewSection()
+	chunk.Sections[sectionIndex].Set(8, 0, 8, coreworld.Block{Namespace: "minecraft", Name: "wall_torch"})
+	mask, empty, arrays := buildBlockLight(localBlockLightRegion(chunk))
+	defer releaseSkyLightPages(arrays)
+	bit := int64(1) << (sectionIndex + 1)
+	if mask&bit == 0 || empty&bit != 0 || len(arrays) == 0 {
+		t.Fatalf("block light masks omit torch section: mask=%026b empty=%026b arrays=%d", mask, empty, len(arrays))
+	}
+}
+
+func TestBlockLightChangeDetectsEmitterPlacementAndRemoval(t *testing.T) {
+	torch := coreworld.Block{Namespace: "minecraft", Name: "torch"}
+	if !BlockLightChanged(coreworld.Air, torch) || !BlockLightChanged(torch, coreworld.Air) {
+		t.Fatal("torch placement/removal did not invalidate block light")
+	}
+	if BlockLightChanged(torch, torch) {
+		t.Fatal("unchanged torch invalidated block light")
+	}
+}

--- a/java/world/sender.go
+++ b/java/world/sender.go
@@ -14,6 +14,7 @@ import (
 // packetIDLevelChunkWithLight is the server-to-client Play packet ID for
 // "Level Chunk With Light", resolved from the embedded protocol data at init.
 var packetIDLevelChunkWithLight = protocoldata.MustCB("play", "minecraft:level_chunk_with_light")
+var packetIDUpdateLight = protocoldata.MustCB("play", "minecraft:update_light")
 
 // Sender converts canonical chunks into Java chunk packets. Heightmaps are
 // derived from each chunk's actual block columns.
@@ -57,19 +58,31 @@ func releaseSkyLightPages(pages [][]byte) {
 //	VarInt     Block entity count, followed by encoded block entities
 //	-- Light update fields --
 //	BitSet     Sky Light Mask (only sections containing sky light)
-//	BitSet     Block Light Mask (empty)
+//	BitSet     Block Light Mask
 //	BitSet     Empty Sky Light Mask (sections with zero sky light)
-//	BitSet     Empty Block Light Mask (all 26 sections)
+//	BitSet     Empty Block Light Mask
 //	VarInt     Sky Light array count
 //	ByteArray  One 2048-byte nibble array per non-empty sky section
-//	VarInt     Block Light array count (0)
+//	VarInt     Block Light array count and 2048-byte nibble arrays
 func (s *Sender) SendChunk(conn *network.ClientConn, c *coreworld.Chunk) error {
+	return s.sendChunk(conn, c, localBlockLightRegion(c))
+}
+
+// SendChunkFromWorld includes emitters from neighbouring chunks so light may
+// cross chunk borders exactly as the canonical block layout permits.
+func (s *Sender) SendChunkFromWorld(conn *network.ClientConn, w *coreworld.World, c *coreworld.Chunk) error {
+	return s.sendChunk(conn, c, worldBlockLightRegion(w, c))
+}
+
+func (s *Sender) sendChunk(conn *network.ClientConn, c *coreworld.Chunk, region blockLightRegion) error {
 	heightmapNBT := EncodeChunkHeightmaps(c)
 	chunkBuffer := acquireChunkBuffer()
 	defer releaseChunkBuffer(chunkBuffer)
 	encodeChunkTo(chunkBuffer, c)
 	skyMask, emptySkyMask, skyArrays := buildSkyLight(c)
 	defer releaseSkyLightPages(skyArrays)
+	blockMask, emptyBlockMask, blockArrays := buildBlockLight(region)
+	defer releaseSkyLightPages(blockArrays)
 
 	type encodedBlockEntity struct {
 		entity coreworld.BlockEntity
@@ -85,7 +98,6 @@ func (s *Sender) SendChunk(conn *network.ClientConn, c *coreworld.Chunk) error {
 		}
 	}
 
-	const allSectionsMask = int64((int64(1) << 26) - 1)
 	b := protocol.NewBuilder(packetIDLevelChunkWithLight).
 		Int(c.X).
 		Int(c.Z).
@@ -98,15 +110,41 @@ func (s *Sender) SendChunk(conn *network.ClientConn, c *coreworld.Chunk) error {
 		b.Byte(packedXZ).Short(int16(entity.Y)).VarInt(encoded.typeID).Bytes(encoded.data)
 	}
 	b.VarInt(1).Long(skyMask).
-		VarInt(0). // block light mask
+		VarInt(1).Long(blockMask).
 		VarInt(1).Long(emptySkyMask).
-		VarInt(1).Long(allSectionsMask). // empty block light mask
+		VarInt(1).Long(emptyBlockMask).
 		VarInt(int32(len(skyArrays)))
 	for _, light := range skyArrays {
 		b.ByteArray(light)
 	}
-	b.VarInt(0) // no block-light arrays
+	b.VarInt(int32(len(blockArrays)))
+	for _, light := range blockArrays {
+		b.ByteArray(light)
+	}
 	return conn.WritePacket(b.Build())
+}
+
+// BuildBlockLightUpdate constructs a standalone Java light update for a chunk.
+// Sky-light masks are untouched; only canonical block-light sections are sent.
+func BuildBlockLightUpdate(w *coreworld.World, c *coreworld.Chunk) *protocol.Packet {
+	if c == nil {
+		return nil
+	}
+	blockMask, emptyBlockMask, blockArrays := buildBlockLight(worldBlockLightRegion(w, c))
+	defer releaseSkyLightPages(blockArrays)
+	b := protocol.NewBuilder(packetIDUpdateLight).
+		VarInt(c.X).
+		VarInt(c.Z).
+		VarInt(0).
+		VarInt(1).Long(blockMask).
+		VarInt(0).
+		VarInt(1).Long(emptyBlockMask).
+		VarInt(0).
+		VarInt(int32(len(blockArrays)))
+	for _, light := range blockArrays {
+		b.ByteArray(light)
+	}
+	return b.Build()
 }
 
 // buildSkyLight returns protocol masks and 2048-byte nibble arrays for the 24
@@ -347,7 +385,7 @@ func (s *Sender) SendChunksAround(conn *network.ClientConn, w *coreworld.World, 
 	for dx := -r; dx <= r; dx++ {
 		for dz := -r; dz <= r; dz++ {
 			c := w.Chunk(cx+int32(dx), cz+int32(dz))
-			if err := s.SendChunk(conn, c); err != nil {
+			if err := s.SendChunkFromWorld(conn, w, c); err != nil {
 				return fmt.Errorf("sending chunk (%d,%d): %w", cx+dx, cz+dz, err)
 			}
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -561,9 +561,6 @@ func New(cfg *config.Config) (*Server, error) {
 		s.sessions.SetExternalKnockbackHandler(func(p *player.Player, sourceX, sourceZ, horizontal, vertical float64) {
 			s.sendLegacyPlayerKnockback(&session.Session{Player: p}, sourceX, sourceZ, horizontal, vertical)
 		})
-		worldInstance.SetBlockObserver(s.bedrockListener.BroadcastBlockChange)
-		netherWorld.SetBlockObserver(s.bedrockListener.DimensionBlockObserver(1))
-		endWorld.SetBlockObserver(s.bedrockListener.DimensionBlockObserver(2))
 	}
 	for dimension, dimensionWorld := range map[int32]*coreworld.World{
 		dimensionOverworld: worldInstance,
@@ -571,6 +568,17 @@ func New(cfg *config.Config) (*Server, error) {
 		dimensionEnd:       endWorld,
 	} {
 		dimension := dimension
+		dimensionWorld := dimensionWorld
+		var bedrockObserver func(coreworld.BlockChange)
+		if s.bedrockListener != nil {
+			bedrockObserver = s.bedrockListener.DimensionBlockObserver(dimension)
+		}
+		dimensionWorld.SetBlockObserver(func(change coreworld.BlockChange) {
+			if bedrockObserver != nil {
+				bedrockObserver(change)
+			}
+			handler.BroadcastBlockLightUpdatesInDimension(dimensionWorld, change, s.sessions, dimension)
+		})
 		dimensionWorld.SetBlockEntityObserver(func(entity coreworld.BlockEntity) {
 			handler.BroadcastBlockEntityDataInDimension(entity, s.sessions, dimension)
 			if s.bedrockListener != nil {


### PR DESCRIPTION
## Summary
- generate and send canonical Java block-light data for initial and streamed chunks
- refresh Java lighting after shared world mutations, including Bedrock-placed torches
- propagate block light across loaded chunk boundaries
- safely respawn remote Bedrock actors after teleport-sized position changes
- preserve vanilla zero mining XP for raw iron and copper ores
- verify the embedded Java server-list icon fallback

## Validation
- go test ./...
- go vet ./...
- go build ./...
- git diff --check

All implementation commits remain below 100 changed lines.