### PR TITLE
feat: add experimental native Go plugin runtime and API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 gocraft-linux-amd64
 gocraft-windows-amd64.exe
 *.exe
+examples/go-plugin/bin/
 
 # Plugin bundles (.gcpkg files) dropped in by the admin.
 # The README is tracked, so use the wildcard pattern instead of plugins/ to

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Connect a Java 1.21.4 client to `localhost:25565`.
 | [Custom Items](docs/custom-items.md) | Cross-edition custom item system — define once, works on Java and Bedrock |
 | [Permissions](docs/permissions.md) | Group-based permission system and the GoPerm browser editor |
 | [Commands](docs/commands.md) | All built-in commands with permission nodes |
+| [Native Go Plugins](docs/go-plugins.md) | Lifecycle, events, commands, packaging, and example plugin |
 | [Bedrock & Cross-play](docs/bedrock.md) | Bedrock setup, shared features, and pack support |
 | [Architecture](docs/architecture.md) | Core design, adapter pattern, project structure |
 | [Command Parity](docs/command-parity.md) | Gaps relative to vanilla Paper/Spigot |
@@ -68,6 +69,7 @@ Connect a Java 1.21.4 client to `localhost:25565`.
 - **Permission editor** — browser-based group editor via bytebin relay, no inbound port needed
 - **MiniMessage** — full gradient, hex color, and glyph support in chat, prefixes, and item names
 - **Resource packs** — push `.mcpack`, `.zip`, and `.mcaddon` files to Bedrock clients; serve Java packs automatically
+- **Native Go plugins** — isolated processes with owned events, commands, scheduling, and configuration
 - **Persistent world** — Anvil region files, autosaves, atomic writes, memory-mode option
 - **Data-driven** — block states, item IDs, entity types, biomes, and packet IDs loaded from versioned JSON at startup; no hardcoded maps
 
@@ -82,7 +84,7 @@ Connect a Java 1.21.4 client to `localhost:25565`.
 | 11–13 — Entity system, commands, data-driven registries | Complete |
 | 14 — Bedrock adapter | Beta |
 | Custom items (Java + Bedrock) | In progress |
-| 15 — Go plugin API | Future |
+| 15 — Go plugin API | Experimental |
 
 Full milestone details are in [`logs/`](logs/).
 

--- a/abi/v1/command_call.go
+++ b/abi/v1/command_call.go
@@ -1,0 +1,9 @@
+package abi
+
+// Internal event and result names used by runtimes until command messages gain
+// dedicated protobuf envelope variants.
+const (
+	EventCommandInvoke    = "gocraft.command.invoke.v1"
+	HostCallCommandReply  = "gocraft.command.reply.v1"
+	HostCallCommandFailed = "gocraft.command.failed.v1"
+)

--- a/docs/go-plugins.md
+++ b/docs/go-plugins.md
@@ -1,0 +1,87 @@
+# Native Go plugins
+
+Native Go plugins are experimental. Each plugin runs as its own process and
+communicates with GoCraft through the versioned, protocol-neutral Plugin API.
+A panic or process crash therefore does not directly crash the server.
+
+## Install a plugin
+
+Put its `.gcpkg` file in `plugins/` and restart GoCraft. The server discovers
+bundles before opening its network listeners. A failed plugin prevents startup
+instead of leaving gameplay partly protected.
+
+Configuration defaults stored under `config/` inside the bundle are copied on
+first load to `plugins/<plugin-id>/`. Existing administrator files are never
+overwritten. `Context.DataDirectory()` returns that directory.
+
+## Lifecycle
+
+Implement `pluginapi.Plugin`:
+
+```go
+type Plugin struct{}
+
+func (*Plugin) OnLoad(ctx pluginapi.Context) error { return nil }
+func (*Plugin) OnEnable() error                    { return nil }
+func (*Plugin) OnDisable() error                   { return nil }
+```
+
+`OnLoad` receives the logger, event registry, command registry, scheduler, and
+data directory. Register callbacks there. `OnEnable` runs after loading and
+`OnDisable` runs during orderly shutdown or failed enable cleanup.
+
+Listeners and command callbacks run synchronously and serially for one plugin.
+Do not block them. Scheduler callbacks run asynchronously. When a plugin is
+disabled, GoCraft unregisters its listeners and commands and cancels its tasks.
+Panics at every callback boundary are recovered and logged with a stack trace.
+
+## Events
+
+The first API version exposes:
+
+| Event | Timing | Cancellable |
+| --- | --- | --- |
+| `PlayerJoinEvent` | after the player is reachable | no |
+| `BlockBreakEvent` | before the block mutation | yes |
+
+Java and Bedrock actions produce these same event types. No packet or numeric
+protocol IDs are exposed. Cancelling `BlockBreakEvent` keeps the block intact
+for either edition.
+
+```go
+ctx.Events().OnBlockBreak(func(event *pluginapi.BlockBreakEvent) {
+    if event.Block.ID == "minecraft:diamond_block" {
+        event.Cancel()
+    }
+})
+```
+
+## Commands
+
+Commands are declared in the bundle's generated `commands.pb`. Register the
+matching executor ID during `OnLoad`:
+
+```go
+ctx.Commands().Register(1, func(call *pluginapi.CommandContext) error {
+    call.Reply("Hello, " + call.SenderName)
+    return nil
+})
+```
+
+The host parses and validates arguments before the callback. Typed values are
+available through `CommandContext.Args`. Replies work for players and console
+senders.
+
+## Build a bundle
+
+See [`examples/go-plugin`](../examples/go-plugin/) for a complete plugin. Build
+its executable for the server operating system, place it at the manifest's
+`entry`, then package it:
+
+```sh
+go run ./cmd/gocraft-cli build -o my-plugin.gcpkg ./my-plugin
+```
+
+Native binaries are operating-system and architecture specific. Hot reload and
+in-process unloading are not supported. Rebuild plugins after a Plugin API
+version change; the host rejects incompatible manifests before executing code.

--- a/examples/go-plugin/README.md
+++ b/examples/go-plugin/README.md
@@ -1,0 +1,30 @@
+# Native Go plugin example
+
+This plugin logs joins and block breaks and provides `/greet`. Its callbacks
+run in a separate process; Java and Bedrock actions use the same event API.
+
+From the GoCraft repository root:
+
+```sh
+go run examples/go-plugin/generate.go
+go build -o examples/go-plugin/bin/example-go ./examples/go-plugin
+go run ./cmd/gocraft-cli build -o example-go.gcpkg ./examples/go-plugin
+```
+
+Copy `example-go.gcpkg` into the server's `plugins/` directory and restart the
+server. GoCraft creates `plugins/example-go/` for configuration and plugin data.
+
+The executable is platform-specific. Build the bundle on the same operating
+system and architecture as the server. Cross-compilation also works, for
+example:
+
+```sh
+GOOS=linux GOARCH=amd64 go build -o examples/go-plugin/bin/example-go ./examples/go-plugin
+```
+
+The command tree is generated as `commands.pb`. Its executor ID (`1`) matches
+the ID passed to `context.Commands().Register` in `main.go`.
+
+Native plugins currently cannot be hot-reloaded or unloaded independently of
+their process. Rebuild the plugin whenever GoCraft's Go version or Plugin API
+version changes.

--- a/examples/go-plugin/commands.pb
+++ b/examples/go-plugin/commands.pb
@@ -1,0 +1,1 @@
+greetexample.greet0

--- a/examples/go-plugin/generate.go
+++ b/examples/go-plugin/generate.go
@@ -1,0 +1,38 @@
+//go:build ignore
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	wire "GoCraft/abi/v1/wire"
+	"google.golang.org/protobuf/proto"
+)
+
+func main() {
+	tree := &wire.CommandTree{
+		Version: 1,
+		Children: []*wire.CommandNode{{
+			Kind:       wire.CommandNodeKind_COMMAND_NODE_KIND_LITERAL,
+			Name:       "greet",
+			Permission: "example.greet",
+			Executor:   1,
+		}},
+	}
+	encoded, err := proto.Marshal(tree)
+	if err != nil {
+		panic(err)
+	}
+	_, source, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("cannot find generator directory")
+	}
+	target := filepath.Join(filepath.Dir(source), "commands.pb")
+	if err := os.WriteFile(target, encoded, 0o644); err != nil {
+		panic(err)
+	}
+	fmt.Println(target)
+}

--- a/examples/go-plugin/main.go
+++ b/examples/go-plugin/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"GoCraft/pluginapi"
+)
+
+var metadata = pluginapi.Metadata{
+	ID: "example-go", Version: "1.0.0", APIVersion: pluginapi.CurrentVersion,
+}
+
+type examplePlugin struct {
+	context pluginapi.Context
+}
+
+func (p *examplePlugin) OnLoad(context pluginapi.Context) error {
+	p.context = context
+	context.Logger().Info("loaded", "data", context.DataDirectory())
+	if err := context.Events().OnPlayerJoin(func(event *pluginapi.PlayerJoinEvent) {
+		context.Logger().Info("player joined", "player", event.Player.Username,
+			"edition", event.Player.Edition)
+	}); err != nil {
+		return err
+	}
+	if err := context.Events().OnBlockBreak(func(event *pluginapi.BlockBreakEvent) {
+		context.Logger().Info("block broken", "player", event.Player.Username,
+			"block", event.Block.ID, "position", event.Position)
+	}); err != nil {
+		return err
+	}
+	return context.Commands().Register(1, func(call *pluginapi.CommandContext) error {
+		call.Reply(fmt.Sprintf("Hello, %s!", call.SenderName))
+		return nil
+	})
+}
+
+func (p *examplePlugin) OnEnable() error {
+	p.context.Logger().Info("enabled")
+	return nil
+}
+
+func (p *examplePlugin) OnDisable() error {
+	p.context.Logger().Info("disabled")
+	return nil
+}
+
+func main() {
+	if err := pluginapi.Run(metadata, &examplePlugin{}); err != nil {
+		slog.Error("example plugin stopped", "err", err)
+		os.Exit(1)
+	}
+}

--- a/examples/go-plugin/plugin.toml
+++ b/examples/go-plugin/plugin.toml
@@ -1,0 +1,11 @@
+id = "example-go"
+version = "1.0.0"
+api = 1
+runtime = "go"
+entry = "bin/example-go"
+
+[subscribe]
+events = ["player.join", "block.break"]
+
+[commands]
+tree = "commands.pb"

--- a/pluginapi/api.go
+++ b/pluginapi/api.go
@@ -1,0 +1,52 @@
+// Package pluginapi is the public API used by native Go plugins.
+package pluginapi
+
+import "log/slog"
+
+// CurrentVersion is the Go Plugin API version supported by this server.
+const CurrentVersion uint32 = 1
+
+// Metadata identifies a compiled plugin. The bundle manifest remains the
+// host's authoritative copy and is checked before plugin code starts.
+type Metadata struct {
+	ID         string
+	Version    string
+	APIVersion uint32
+}
+
+// Plugin is the lifecycle implemented by a native Go plugin.
+type Plugin interface {
+	OnLoad(Context) error
+	OnEnable() error
+	OnDisable() error
+}
+
+// Context exposes resources owned by one plugin.
+type Context interface {
+	Metadata() Metadata
+	DataDirectory() string
+	Logger() *slog.Logger
+	Events() *Events
+	Commands() *Commands
+	Scheduler() *Scheduler
+}
+
+// Player is a protocol-independent player reference.
+type Player struct {
+	UUID     [16]byte
+	Username string
+	Edition  string
+}
+
+// BlockPos is an integer position in a world.
+type BlockPos struct {
+	X int32
+	Y int32
+	Z int32
+}
+
+// Block is a namespaced block state snapshot.
+type Block struct {
+	ID         string
+	Properties map[string]string
+}

--- a/pluginapi/command.go
+++ b/pluginapi/command.go
@@ -1,0 +1,65 @@
+package pluginapi
+
+import "time"
+
+type CommandValueKind uint8
+
+const (
+	CommandInteger CommandValueKind = iota + 1
+	CommandDecimal
+	CommandString
+	CommandGreedy
+	CommandPlayer
+	CommandBlockPos
+	CommandBlockState
+	CommandItem
+	CommandDuration
+	CommandEnum
+	CommandCustom
+)
+
+// CommandHandler handles one executor declared in the bundle's command tree.
+type CommandHandler func(*CommandContext) error
+
+// CommandContext contains host-validated command arguments.
+type CommandContext struct {
+	Sender  *Player
+	Args    CommandValues
+	replies []string
+}
+
+// Reply sends text to the player who invoked the command.
+func (c *CommandContext) Reply(message string) {
+	if message != "" {
+		c.replies = append(c.replies, message)
+	}
+}
+
+// CommandValue is one typed command argument.
+type CommandValue struct {
+	Kind     CommandValueKind
+	Integer  int64
+	Decimal  float64
+	Text     string
+	Player   *Player
+	Position BlockPos
+	Block    Block
+	Item     string
+	Duration time.Duration
+}
+
+// CommandValues is keyed by the argument name from the command tree.
+type CommandValues map[string]CommandValue
+
+func (v CommandValues) String(name string) (string, bool) {
+	value, ok := v[name]
+	if !ok || value.Text == "" {
+		return "", false
+	}
+	return value.Text, true
+}
+
+func (v CommandValues) Integer(name string) (int64, bool) {
+	value, ok := v[name]
+	return value.Integer, ok
+}

--- a/pluginapi/command.go
+++ b/pluginapi/command.go
@@ -23,9 +23,10 @@ type CommandHandler func(*CommandContext) error
 
 // CommandContext contains host-validated command arguments.
 type CommandContext struct {
-	Sender  *Player
-	Args    CommandValues
-	replies []string
+	Sender     *Player
+	SenderName string
+	Args       CommandValues
+	replies    []string
 }
 
 // Reply sends text to the player who invoked the command.

--- a/pluginapi/command_dispatch.go
+++ b/pluginapi/command_dispatch.go
@@ -1,0 +1,87 @@
+package pluginapi
+
+import (
+	"fmt"
+	"math"
+
+	abi "GoCraft/abi/v1"
+)
+
+func (s *runtimeState) invokeCommand(event *abi.Event) (abi.Verdict, error) {
+	if !s.enabled || s.context == nil {
+		return abi.Verdict{}, fmt.Errorf("pluginapi: plugin is not enabled")
+	}
+	executor, call, err := commandContextFrom(event)
+	if err != nil {
+		return abi.Verdict{}, err
+	}
+	replies, callErr := s.context.commands.invoke(executor, call)
+	verdict := abi.Verdict{}
+	for _, reply := range replies {
+		verdict.Effects = append(verdict.Effects, abi.HostCall{
+			Type: abi.HostCallCommandReply, Fields: []abi.Value{abi.String(reply)},
+		})
+	}
+	if callErr != nil {
+		verdict.Effects = append(verdict.Effects, abi.HostCall{
+			Type: abi.HostCallCommandFailed, Fields: []abi.Value{abi.String(callErr.Error())},
+		})
+	}
+	return verdict, nil
+}
+
+func commandContextFrom(event *abi.Event) (uint32, *CommandContext, error) {
+	if event == nil || len(event.Fields) != 4 {
+		return 0, nil, fmt.Errorf("pluginapi: malformed command invocation")
+	}
+	executor := event.Fields[0]
+	if executor.Kind != abi.ValueInt64 || executor.Int64 < 0 || executor.Int64 > math.MaxUint32 {
+		return 0, nil, fmt.Errorf("pluginapi: invalid command executor")
+	}
+	var sender *Player
+	if value := event.Fields[1]; value.Kind != abi.ValueList || len(value.List) != 0 {
+		decoded, err := playerFrom(value)
+		if err != nil {
+			return 0, nil, err
+		}
+		sender = &decoded
+	}
+	name, err := stringFrom(event.Fields[2], "command sender name")
+	if err != nil {
+		return 0, nil, err
+	}
+	arguments, err := commandValuesFrom(event.Fields[3])
+	if err != nil {
+		return 0, nil, err
+	}
+	return uint32(executor.Int64), &CommandContext{Sender: sender, SenderName: name, Args: arguments}, nil
+}
+
+func commandValuesFrom(value abi.Value) (CommandValues, error) {
+	if value.Kind != abi.ValueList {
+		return nil, fmt.Errorf("pluginapi: command arguments are not a list")
+	}
+	values := make(CommandValues, len(value.List))
+	for _, item := range value.List {
+		entry, err := listOf(item, 3, "command argument")
+		if err != nil {
+			return nil, err
+		}
+		name, err := stringFrom(entry[0], "command argument name")
+		if err != nil {
+			return nil, err
+		}
+		if entry[1].Kind != abi.ValueInt64 {
+			return nil, fmt.Errorf("pluginapi: command argument kind is not an integer")
+		}
+		if _, duplicate := values[name]; duplicate {
+			return nil, fmt.Errorf("pluginapi: duplicate command argument %s", name)
+		}
+		decoded, err := commandValueFrom(CommandValueKind(entry[1].Int64), entry[2])
+		if err != nil {
+			return nil, err
+		}
+		values[name] = decoded
+	}
+	return values, nil
+}

--- a/pluginapi/command_dispatch_test.go
+++ b/pluginapi/command_dispatch_test.go
@@ -1,0 +1,54 @@
+package pluginapi
+
+import (
+	"errors"
+	"testing"
+
+	abi "GoCraft/abi/v1"
+)
+
+type wireCommandPlugin struct{}
+
+func (*wireCommandPlugin) OnLoad(context Context) error {
+	return context.Commands().Register(7, func(call *CommandContext) error {
+		amount, ok := call.Args.Integer("amount")
+		if !ok || amount != 3 || call.SenderName != "Console" || call.Sender != nil {
+			return errors.New("bad command context")
+		}
+		call.Reply("created three blocks")
+		return errors.New("example failure")
+	})
+}
+
+func (*wireCommandPlugin) OnEnable() error  { return nil }
+func (*wireCommandPlugin) OnDisable() error { return nil }
+
+func TestRuntimeCommandDispatchReturnsRepliesAndErrors(t *testing.T) {
+	state := newRuntimeState(Metadata{ID: "commands"}, &wireCommandPlugin{})
+	if _, err := state.load("commands", "data"); err != nil {
+		t.Fatal(err)
+	}
+	event := &abi.Event{Type: abi.EventCommandInvoke, Fields: []abi.Value{
+		abi.Int64(7), abi.List(), abi.String("Console"),
+		abi.List(abi.List(abi.String("amount"), abi.Int64(int64(CommandInteger)), abi.Int64(3))),
+	}}
+	verdict, err := state.invokeCommand(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(verdict.Effects) != 2 || verdict.Effects[0].Type != abi.HostCallCommandReply ||
+		verdict.Effects[0].Fields[0].String != "created three blocks" ||
+		verdict.Effects[1].Type != abi.HostCallCommandFailed {
+		t.Fatalf("command effects = %#v", verdict.Effects)
+	}
+}
+
+func TestRuntimeCommandDispatchRejectsMalformedCall(t *testing.T) {
+	state := newRuntimeState(Metadata{ID: "commands"}, &wireCommandPlugin{})
+	if _, err := state.load("commands", "data"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.invokeCommand(&abi.Event{Type: abi.EventCommandInvoke}); err == nil {
+		t.Fatal("malformed command call was accepted")
+	}
+}

--- a/pluginapi/command_registry.go
+++ b/pluginapi/command_registry.go
@@ -1,0 +1,52 @@
+package pluginapi
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+// Register binds a local executor ID from commands.pb to a callback.
+func (c *Commands) Register(executor uint32, handler CommandHandler) error {
+	if executor == 0 || handler == nil {
+		return fmt.Errorf("pluginapi: command executor and handler are required")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.active {
+		return fmt.Errorf("pluginapi: command registry is disabled")
+	}
+	if _, duplicate := c.handlers[executor]; duplicate {
+		return fmt.Errorf("pluginapi: command executor %d is already registered", executor)
+	}
+	c.handlers[executor] = handler
+	return nil
+}
+
+func (c *Commands) invoke(executor uint32, call *CommandContext) (replies []string, err error) {
+	c.mu.RLock()
+	handler, ok := c.handlers[executor]
+	active := c.active
+	c.mu.RUnlock()
+	if !active {
+		return nil, fmt.Errorf("pluginapi: command registry is disabled")
+	}
+	if !ok {
+		return nil, fmt.Errorf("pluginapi: command executor %d is not registered", executor)
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			c.logger.Error("plugin command panicked", "executor", executor,
+				"panic", recovered, "stack", string(debug.Stack()))
+			err = fmt.Errorf("plugin command %d panicked", executor)
+		}
+	}()
+	err = handler(call)
+	return append([]string(nil), call.replies...), err
+}
+
+func (c *Commands) clear() {
+	c.mu.Lock()
+	c.active = false
+	c.handlers = make(map[uint32]CommandHandler)
+	c.mu.Unlock()
+}

--- a/pluginapi/command_registry_test.go
+++ b/pluginapi/command_registry_test.go
@@ -1,0 +1,47 @@
+package pluginapi
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestCommandsRegisterInvokeAndClear(t *testing.T) {
+	var output bytes.Buffer
+	commands := newCommands(testLogger(&output))
+	wantErr := errors.New("example failure")
+	if err := commands.Register(7, func(call *CommandContext) error {
+		call.Reply("hello " + call.Sender.Username)
+		return wantErr
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := commands.Register(7, func(*CommandContext) error { return nil }); err == nil {
+		t.Fatal("duplicate executor was accepted")
+	}
+	replies, err := commands.invoke(7, &CommandContext{Sender: &Player{Username: "Elias"}})
+	if !errors.Is(err, wantErr) || len(replies) != 1 || replies[0] != "hello Elias" {
+		t.Fatalf("invoke() = %v, %v", replies, err)
+	}
+	commands.clear()
+	if _, err := commands.invoke(7, &CommandContext{}); err == nil {
+		t.Fatal("disabled registry invoked a command")
+	}
+}
+
+func TestCommandsRecoverPanics(t *testing.T) {
+	var output bytes.Buffer
+	commands := newCommands(testLogger(&output))
+	if err := commands.Register(3, func(*CommandContext) error {
+		panic("command exploded")
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := commands.invoke(3, &CommandContext{}); err == nil {
+		t.Fatal("panicking command returned no error")
+	}
+	if log := output.String(); !strings.Contains(log, "command exploded") || !strings.Contains(log, "stack") {
+		t.Fatalf("panic log = %q", log)
+	}
+}

--- a/pluginapi/command_value_decode.go
+++ b/pluginapi/command_value_decode.go
@@ -1,0 +1,66 @@
+package pluginapi
+
+import (
+	"fmt"
+	"time"
+
+	abi "GoCraft/abi/v1"
+)
+
+func commandValueFrom(kind CommandValueKind, value abi.Value) (CommandValue, error) {
+	decoded := CommandValue{Kind: kind}
+	switch kind {
+	case CommandInteger:
+		if value.Kind != abi.ValueInt64 {
+			return decoded, wrongCommandValue(kind)
+		}
+		decoded.Integer = value.Int64
+	case CommandDecimal:
+		if value.Kind != abi.ValueDouble {
+			return decoded, wrongCommandValue(kind)
+		}
+		decoded.Decimal = value.Double
+	case CommandString, CommandGreedy, CommandEnum, CommandCustom:
+		text, err := stringFrom(value, "command argument")
+		if err != nil {
+			return decoded, err
+		}
+		decoded.Text = text
+	case CommandPlayer:
+		player, err := playerFrom(value)
+		if err != nil {
+			return decoded, err
+		}
+		decoded.Player = &player
+	case CommandBlockPos:
+		position, err := positionFrom(value)
+		if err != nil {
+			return decoded, err
+		}
+		decoded.Position = position
+	case CommandBlockState:
+		block, err := blockFrom(value)
+		if err != nil {
+			return decoded, err
+		}
+		decoded.Block = block
+	case CommandItem:
+		item, err := stringFrom(value, "item argument")
+		if err != nil {
+			return decoded, err
+		}
+		decoded.Item = item
+	case CommandDuration:
+		if value.Kind != abi.ValueInt64 {
+			return decoded, wrongCommandValue(kind)
+		}
+		decoded.Duration = time.Duration(value.Int64)
+	default:
+		return decoded, fmt.Errorf("pluginapi: unsupported command value kind %d", kind)
+	}
+	return decoded, nil
+}
+
+func wrongCommandValue(kind CommandValueKind) error {
+	return fmt.Errorf("pluginapi: invalid value for command kind %d", kind)
+}

--- a/pluginapi/context.go
+++ b/pluginapi/context.go
@@ -1,0 +1,30 @@
+package pluginapi
+
+import "log/slog"
+
+type pluginContext struct {
+	metadata  Metadata
+	data      string
+	logger    *slog.Logger
+	events    *Events
+	commands  *Commands
+	scheduler *Scheduler
+}
+
+func newContext(metadata Metadata, data string, logger *slog.Logger) *pluginContext {
+	return &pluginContext{
+		metadata:  metadata,
+		data:      data,
+		logger:    logger,
+		events:    newEvents(logger),
+		commands:  newCommands(logger),
+		scheduler: newScheduler(logger),
+	}
+}
+
+func (c *pluginContext) Metadata() Metadata    { return c.metadata }
+func (c *pluginContext) DataDirectory() string { return c.data }
+func (c *pluginContext) Logger() *slog.Logger  { return c.logger }
+func (c *pluginContext) Events() *Events       { return c.events }
+func (c *pluginContext) Commands() *Commands   { return c.commands }
+func (c *pluginContext) Scheduler() *Scheduler { return c.scheduler }

--- a/pluginapi/dispatch.go
+++ b/pluginapi/dispatch.go
@@ -1,0 +1,80 @@
+package pluginapi
+
+import (
+	"fmt"
+
+	abi "GoCraft/abi/v1"
+)
+
+func (s *runtimeState) dispatch(incoming *abi.Event) (abi.Verdict, error) {
+	if !s.enabled || s.context == nil {
+		return abi.Verdict{}, fmt.Errorf("pluginapi: plugin is not enabled")
+	}
+	event, err := eventFrom(incoming)
+	if err != nil {
+		return abi.Verdict{}, err
+	}
+	s.context.events.dispatch(event)
+	verdict := abi.Verdict{}
+	if cancellable, ok := event.(CancellableEvent); ok {
+		verdict.Cancelled = cancellable.Cancelled()
+	}
+	return verdict, nil
+}
+
+func eventFrom(incoming *abi.Event) (Event, error) {
+	if incoming == nil {
+		return nil, fmt.Errorf("pluginapi: missing event")
+	}
+	switch incoming.Type {
+	case EventPlayerJoin:
+		return playerJoinFrom(incoming.Fields)
+	case EventBlockBreak:
+		return blockBreakFrom(incoming.Fields)
+	default:
+		return nil, fmt.Errorf("pluginapi: unsupported event %s", incoming.Type)
+	}
+}
+
+func playerJoinFrom(fields []abi.Value) (*PlayerJoinEvent, error) {
+	if len(fields) != 2 {
+		return nil, fmt.Errorf("pluginapi: player.join has %d fields, want 2", len(fields))
+	}
+	player, err := playerFrom(fields[0])
+	if err != nil {
+		return nil, err
+	}
+	permissions, err := permissionsFrom(fields[1])
+	if err != nil {
+		return nil, err
+	}
+	return &PlayerJoinEvent{Player: player, Permissions: permissions}, nil
+}
+
+func blockBreakFrom(fields []abi.Value) (*BlockBreakEvent, error) {
+	if len(fields) != 5 {
+		return nil, fmt.Errorf("pluginapi: block.break has %d fields, want 5", len(fields))
+	}
+	player, err := playerFrom(fields[0])
+	if err != nil {
+		return nil, err
+	}
+	position, err := positionFrom(fields[1])
+	if err != nil {
+		return nil, err
+	}
+	block, err := blockFrom(fields[2])
+	if err != nil {
+		return nil, err
+	}
+	tool, err := stringFrom(fields[3], "block break tool")
+	if err != nil {
+		return nil, err
+	}
+	permissions, err := permissionsFrom(fields[4])
+	if err != nil {
+		return nil, err
+	}
+	return &BlockBreakEvent{Player: player, Position: position, Block: block,
+		Tool: tool, Permissions: permissions}, nil
+}

--- a/pluginapi/dispatch_test.go
+++ b/pluginapi/dispatch_test.go
@@ -1,0 +1,70 @@
+package pluginapi
+
+import (
+	"testing"
+
+	abi "GoCraft/abi/v1"
+)
+
+type eventPlugin struct {
+	joins, breaks int
+}
+
+func (p *eventPlugin) OnLoad(context Context) error {
+	if err := context.Events().OnPlayerJoin(func(*PlayerJoinEvent) { p.joins++ }); err != nil {
+		return err
+	}
+	return context.Events().OnBlockBreak(func(event *BlockBreakEvent) {
+		p.breaks++
+		event.Cancel()
+	})
+}
+
+func (*eventPlugin) OnEnable() error  { return nil }
+func (*eventPlugin) OnDisable() error { return nil }
+
+func TestRuntimeDispatchesEventsOnceAndReturnsCancellation(t *testing.T) {
+	implementation := &eventPlugin{}
+	state := newRuntimeState(Metadata{ID: "events"}, implementation)
+	if _, err := state.load("events", "data"); err != nil {
+		t.Fatal(err)
+	}
+	player := abi.List(abi.Bytes(make([]byte, 16)), abi.String("Elias"), abi.String("java"))
+	permissions := abi.List(abi.List(abi.String("world.break"), abi.Bool(true)))
+	block := abi.List(abi.String("minecraft:stone"), abi.List())
+	incoming := &abi.Event{Type: EventBlockBreak, Fields: []abi.Value{
+		player,
+		abi.List(abi.Int64(1), abi.Int64(64), abi.Int64(2)),
+		block,
+		abi.String("minecraft:diamond_pickaxe"),
+		permissions,
+	}}
+	verdict, err := state.dispatch(incoming)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !verdict.Cancelled || implementation.breaks != 1 {
+		t.Fatalf("verdict cancelled=%v, calls=%d", verdict.Cancelled, implementation.breaks)
+	}
+	if _, err := state.dispatch(&abi.Event{Type: EventPlayerJoin,
+		Fields: []abi.Value{player, permissions}}); err != nil {
+		t.Fatal(err)
+	}
+	if implementation.joins != 1 {
+		t.Fatalf("player.join dispatched %d times", implementation.joins)
+	}
+}
+
+func TestRuntimeRejectsMalformedEvents(t *testing.T) {
+	state := newRuntimeState(Metadata{ID: "events"}, &eventPlugin{})
+	if _, err := state.load("events", "data"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.dispatch(&abi.Event{Type: EventBlockBreak}); err == nil {
+		t.Fatal("malformed block break was accepted")
+	}
+	state.disable()
+	if _, err := state.dispatch(&abi.Event{Type: EventPlayerJoin}); err == nil {
+		t.Fatal("disabled plugin received an event")
+	}
+}

--- a/pluginapi/event_registry.go
+++ b/pluginapi/event_registry.go
@@ -1,0 +1,78 @@
+package pluginapi
+
+import (
+	"fmt"
+	"runtime/debug"
+	"sort"
+	"strings"
+)
+
+// On registers a listener owned by this plugin.
+func (e *Events) On(eventType string, handler EventHandler) error {
+	eventType = strings.TrimSpace(eventType)
+	if eventType == "" || handler == nil {
+		return fmt.Errorf("pluginapi: event type and handler are required")
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if !e.active {
+		return fmt.Errorf("pluginapi: event registry is disabled")
+	}
+	e.listeners[eventType] = append(e.listeners[eventType], handler)
+	return nil
+}
+
+func (e *Events) OnPlayerJoin(handler func(*PlayerJoinEvent)) error {
+	if handler == nil {
+		return fmt.Errorf("pluginapi: player join handler is required")
+	}
+	return e.On(EventPlayerJoin, func(event Event) { handler(event.(*PlayerJoinEvent)) })
+}
+
+func (e *Events) OnBlockBreak(handler func(*BlockBreakEvent)) error {
+	if handler == nil {
+		return fmt.Errorf("pluginapi: block break handler is required")
+	}
+	return e.On(EventBlockBreak, func(event Event) { handler(event.(*BlockBreakEvent)) })
+}
+
+func (e *Events) registeredTypes() []string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	types := make([]string, 0, len(e.listeners))
+	for eventType := range e.listeners {
+		types = append(types, eventType)
+	}
+	sort.Strings(types)
+	return types
+}
+
+func (e *Events) dispatch(event Event) {
+	e.mu.RLock()
+	if !e.active {
+		e.mu.RUnlock()
+		return
+	}
+	listeners := append([]EventHandler(nil), e.listeners[event.Type()]...)
+	e.mu.RUnlock()
+	for _, listener := range listeners {
+		e.call(listener, event)
+	}
+}
+
+func (e *Events) call(listener EventHandler, event Event) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			e.logger.Error("plugin event panicked", "event", event.Type(),
+				"panic", recovered, "stack", string(debug.Stack()))
+		}
+	}()
+	listener(event)
+}
+
+func (e *Events) clear() {
+	e.mu.Lock()
+	e.active = false
+	e.listeners = make(map[string][]EventHandler)
+	e.mu.Unlock()
+}

--- a/pluginapi/event_registry_test.go
+++ b/pluginapi/event_registry_test.go
@@ -1,0 +1,58 @@
+package pluginapi
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func testLogger(output *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(output, nil))
+}
+
+func TestEventsDispatchInOrderAndRecoverPanics(t *testing.T) {
+	var output bytes.Buffer
+	events := newEvents(testLogger(&output))
+	called := 0
+	if err := events.OnBlockBreak(func(*BlockBreakEvent) {
+		called++
+		panic("broken listener")
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := events.OnBlockBreak(func(event *BlockBreakEvent) {
+		called++
+		event.Cancel()
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	event := &BlockBreakEvent{}
+	events.dispatch(event)
+	if called != 2 || !event.Cancelled() {
+		t.Fatalf("dispatch called %d listeners, cancelled=%v", called, event.Cancelled())
+	}
+	if log := output.String(); !strings.Contains(log, "broken listener") || !strings.Contains(log, "stack") {
+		t.Fatalf("panic log = %q", log)
+	}
+	if registered := events.registeredTypes(); len(registered) != 1 || registered[0] != EventBlockBreak {
+		t.Fatalf("registeredTypes() = %v", registered)
+	}
+}
+
+func TestEventsClearPreventsFutureCallbacks(t *testing.T) {
+	events := newEvents(slog.Default())
+	called := false
+	if err := events.OnPlayerJoin(func(*PlayerJoinEvent) { called = true }); err != nil {
+		t.Fatal(err)
+	}
+	events.clear()
+	events.dispatch(&PlayerJoinEvent{})
+	if called {
+		t.Fatal("disabled registry invoked a listener")
+	}
+	if err := events.OnPlayerJoin(func(*PlayerJoinEvent) {}); err == nil {
+		t.Fatal("disabled registry accepted a listener")
+	}
+}

--- a/pluginapi/events.go
+++ b/pluginapi/events.go
@@ -1,0 +1,45 @@
+package pluginapi
+
+const (
+	EventBlockBreak = "block.break"
+	EventPlayerJoin = "player.join"
+)
+
+// Event is a protocol-independent gameplay fact.
+type Event interface {
+	Type() string
+}
+
+// CancellableEvent is implemented by events emitted before a mutation.
+type CancellableEvent interface {
+	Event
+	Cancel()
+	Cancelled() bool
+}
+
+// EventHandler receives events serially for one plugin.
+type EventHandler func(Event)
+
+// PlayerJoinEvent is emitted after a player becomes reachable.
+type PlayerJoinEvent struct {
+	Player      Player
+	Permissions map[string]bool
+}
+
+func (*PlayerJoinEvent) Type() string { return EventPlayerJoin }
+
+// BlockBreakEvent is emitted before a block is removed.
+type BlockBreakEvent struct {
+	Player      Player
+	Position    BlockPos
+	Block       Block
+	Tool        string
+	Permissions map[string]bool
+	cancelled   bool
+}
+
+func (*BlockBreakEvent) Type() string { return EventBlockBreak }
+
+func (e *BlockBreakEvent) Cancel() { e.cancelled = true }
+
+func (e *BlockBreakEvent) Cancelled() bool { return e.cancelled }

--- a/pluginapi/events_test.go
+++ b/pluginapi/events_test.go
@@ -1,0 +1,21 @@
+package pluginapi
+
+import "testing"
+
+func TestBlockBreakEventCancellation(t *testing.T) {
+	event := &BlockBreakEvent{
+		Player:   Player{Username: "Elias"},
+		Position: BlockPos{X: 4, Y: 64, Z: -2},
+		Block:    Block{ID: "minecraft:stone"},
+	}
+	if event.Type() != EventBlockBreak {
+		t.Fatalf("Type() = %q", event.Type())
+	}
+	if event.Cancelled() {
+		t.Fatal("new event is cancelled")
+	}
+	event.Cancel()
+	if !event.Cancelled() {
+		t.Fatal("Cancel() did not persist")
+	}
+}

--- a/pluginapi/lifecycle.go
+++ b/pluginapi/lifecycle.go
@@ -29,6 +29,7 @@ func (s *runtimeState) load(pluginID, dataDirectory string) ([]string, error) {
 	s.context = newContext(s.metadata, dataDirectory, logger)
 	if err := s.call("load", func() error { return s.implementation.OnLoad(s.context) }); err != nil {
 		s.cleanup()
+		s.context = nil
 		return nil, err
 	}
 	s.initialized = true

--- a/pluginapi/lifecycle.go
+++ b/pluginapi/lifecycle.go
@@ -1,0 +1,79 @@
+package pluginapi
+
+import (
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+)
+
+type runtimeState struct {
+	metadata       Metadata
+	implementation Plugin
+	context        *pluginContext
+	initialized    bool
+	enabled        bool
+}
+
+func newRuntimeState(metadata Metadata, implementation Plugin) *runtimeState {
+	return &runtimeState{metadata: metadata, implementation: implementation}
+}
+
+func (s *runtimeState) load(pluginID, dataDirectory string) ([]string, error) {
+	if s.context != nil {
+		return nil, fmt.Errorf("pluginapi: plugin is already loaded")
+	}
+	if pluginID != s.metadata.ID {
+		return nil, fmt.Errorf("pluginapi: executable is %s, bundle requested %s", s.metadata.ID, pluginID)
+	}
+	logger := slog.Default().With("plugin", s.metadata.ID)
+	s.context = newContext(s.metadata, dataDirectory, logger)
+	if err := s.call("load", func() error { return s.implementation.OnLoad(s.context) }); err != nil {
+		s.cleanup()
+		return nil, err
+	}
+	s.initialized = true
+	if err := s.call("enable", s.implementation.OnEnable); err != nil {
+		disableErr := s.disable()
+		if disableErr != nil {
+			logger.Error("plugin cleanup failed", "err", disableErr)
+		}
+		return nil, err
+	}
+	s.enabled = true
+	return s.context.events.registeredTypes(), nil
+}
+
+func (s *runtimeState) disable() error {
+	if s.context == nil {
+		return nil
+	}
+	s.cleanup()
+	var err error
+	if s.initialized {
+		err = s.call("disable", s.implementation.OnDisable)
+	}
+	s.context = nil
+	s.initialized = false
+	s.enabled = false
+	return err
+}
+
+func (s *runtimeState) cleanup() {
+	s.context.events.clear()
+	s.context.commands.clear()
+	s.context.scheduler.stop()
+}
+
+func (s *runtimeState) call(phase string, callback func() error) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			slog.Error("plugin lifecycle panicked", "plugin", s.metadata.ID,
+				"phase", phase, "panic", recovered, "stack", string(debug.Stack()))
+			err = fmt.Errorf("plugin %s %s panicked: %v", s.metadata.ID, phase, recovered)
+		}
+	}()
+	if err := callback(); err != nil {
+		return fmt.Errorf("plugin %s %s: %w", s.metadata.ID, phase, err)
+	}
+	return nil
+}

--- a/pluginapi/lifecycle_test.go
+++ b/pluginapi/lifecycle_test.go
@@ -1,0 +1,75 @@
+package pluginapi
+
+import (
+	"errors"
+	"testing"
+)
+
+type lifecyclePlugin struct {
+	context               Context
+	loadErr, enableErr    error
+	loads, enables, stops int
+}
+
+func (p *lifecyclePlugin) OnLoad(context Context) error {
+	p.loads++
+	p.context = context
+	if p.loadErr == nil {
+		return context.Events().OnPlayerJoin(func(*PlayerJoinEvent) {})
+	}
+	return p.loadErr
+}
+
+func (p *lifecyclePlugin) OnEnable() error {
+	p.enables++
+	return p.enableErr
+}
+
+func (p *lifecyclePlugin) OnDisable() error {
+	p.stops++
+	return nil
+}
+
+func TestRuntimeStateLifecycle(t *testing.T) {
+	implementation := &lifecyclePlugin{}
+	state := newRuntimeState(Metadata{ID: "example", Version: "1", APIVersion: 1}, implementation)
+	events, err := state.load("example", "plugin-data")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0] != EventPlayerJoin {
+		t.Fatalf("load events = %v", events)
+	}
+	if implementation.context.DataDirectory() != "plugin-data" || !state.enabled {
+		t.Fatal("load did not expose the context or enable the plugin")
+	}
+	if _, err := state.load("example", "plugin-data"); err == nil {
+		t.Fatal("duplicate load was accepted")
+	}
+	if err := state.disable(); err != nil {
+		t.Fatal(err)
+	}
+	if implementation.loads != 1 || implementation.enables != 1 || implementation.stops != 1 {
+		t.Fatalf("lifecycle calls = %d, %d, %d", implementation.loads, implementation.enables, implementation.stops)
+	}
+}
+
+func TestRuntimeStateFailuresCleanOwnership(t *testing.T) {
+	loadFailure := &lifecyclePlugin{loadErr: errors.New("bad config")}
+	state := newRuntimeState(Metadata{ID: "example"}, loadFailure)
+	if _, err := state.load("example", "data"); err == nil || state.context != nil {
+		t.Fatal("load failure retained plugin state")
+	}
+	if loadFailure.stops != 0 {
+		t.Fatal("OnDisable ran before OnLoad completed")
+	}
+
+	enableFailure := &lifecyclePlugin{enableErr: errors.New("not ready")}
+	state = newRuntimeState(Metadata{ID: "example"}, enableFailure)
+	if _, err := state.load("example", "data"); err == nil || state.context != nil {
+		t.Fatal("enable failure retained plugin state")
+	}
+	if enableFailure.stops != 1 {
+		t.Fatal("enable failure did not disable initialized plugin")
+	}
+}

--- a/pluginapi/registries.go
+++ b/pluginapi/registries.go
@@ -1,0 +1,18 @@
+package pluginapi
+
+import "log/slog"
+
+// Events owns listeners registered by one plugin.
+type Events struct{ logger *slog.Logger }
+
+func newEvents(logger *slog.Logger) *Events { return &Events{logger: logger} }
+
+// Commands owns command callbacks registered by one plugin.
+type Commands struct{ logger *slog.Logger }
+
+func newCommands(logger *slog.Logger) *Commands { return &Commands{logger: logger} }
+
+// Scheduler owns asynchronous tasks registered by one plugin.
+type Scheduler struct{ logger *slog.Logger }
+
+func newScheduler(logger *slog.Logger) *Scheduler { return &Scheduler{logger: logger} }

--- a/pluginapi/registries.go
+++ b/pluginapi/registries.go
@@ -18,9 +18,16 @@ func newEvents(logger *slog.Logger) *Events {
 }
 
 // Commands owns command callbacks registered by one plugin.
-type Commands struct{ logger *slog.Logger }
+type Commands struct {
+	mu       sync.RWMutex
+	logger   *slog.Logger
+	handlers map[uint32]CommandHandler
+	active   bool
+}
 
-func newCommands(logger *slog.Logger) *Commands { return &Commands{logger: logger} }
+func newCommands(logger *slog.Logger) *Commands {
+	return &Commands{logger: logger, handlers: make(map[uint32]CommandHandler), active: true}
+}
 
 // Scheduler owns asynchronous tasks registered by one plugin.
 type Scheduler struct{ logger *slog.Logger }

--- a/pluginapi/registries.go
+++ b/pluginapi/registries.go
@@ -1,11 +1,20 @@
 package pluginapi
 
-import "log/slog"
+import (
+	"log/slog"
+	"sync"
+)
 
 // Events owns listeners registered by one plugin.
-type Events struct{ logger *slog.Logger }
+type Events struct {
+	mu        sync.RWMutex
+	logger    *slog.Logger
+	listeners map[string][]EventHandler
+}
 
-func newEvents(logger *slog.Logger) *Events { return &Events{logger: logger} }
+func newEvents(logger *slog.Logger) *Events {
+	return &Events{logger: logger, listeners: make(map[string][]EventHandler)}
+}
 
 // Commands owns command callbacks registered by one plugin.
 type Commands struct{ logger *slog.Logger }

--- a/pluginapi/registries.go
+++ b/pluginapi/registries.go
@@ -1,6 +1,7 @@
 package pluginapi
 
 import (
+	"context"
 	"log/slog"
 	"sync"
 )
@@ -30,6 +31,15 @@ func newCommands(logger *slog.Logger) *Commands {
 }
 
 // Scheduler owns asynchronous tasks registered by one plugin.
-type Scheduler struct{ logger *slog.Logger }
+type Scheduler struct {
+	mu      sync.Mutex
+	logger  *slog.Logger
+	next    TaskID
+	active  bool
+	cancels map[TaskID]context.CancelFunc
+	wait    sync.WaitGroup
+}
 
-func newScheduler(logger *slog.Logger) *Scheduler { return &Scheduler{logger: logger} }
+func newScheduler(logger *slog.Logger) *Scheduler {
+	return &Scheduler{logger: logger, active: true, cancels: make(map[TaskID]context.CancelFunc)}
+}

--- a/pluginapi/registries.go
+++ b/pluginapi/registries.go
@@ -10,10 +10,11 @@ type Events struct {
 	mu        sync.RWMutex
 	logger    *slog.Logger
 	listeners map[string][]EventHandler
+	active    bool
 }
 
 func newEvents(logger *slog.Logger) *Events {
-	return &Events{logger: logger, listeners: make(map[string][]EventHandler)}
+	return &Events{logger: logger, listeners: make(map[string][]EventHandler), active: true}
 }
 
 // Commands owns command callbacks registered by one plugin.

--- a/pluginapi/run.go
+++ b/pluginapi/run.go
@@ -1,0 +1,51 @@
+package pluginapi
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+	"time"
+
+	wire "GoCraft/abi/v1/wire"
+	"GoCraft/runtime/ipc"
+)
+
+const connectTimeout = 10 * time.Second
+
+// Run connects a compiled Go plugin to the GoCraft process and serves it until
+// the host requests shutdown. Plugin binaries should call Run from main.
+func Run(metadata Metadata, implementation Plugin) error {
+	if err := validateMetadata(metadata, implementation); err != nil {
+		return err
+	}
+	options, err := parseRunnerOptions(os.Args[1:])
+	if err != nil {
+		return err
+	}
+	stream, err := net.DialTimeout("unix", options.socket, connectTimeout)
+	if err != nil {
+		return fmt.Errorf("pluginapi: connect to host: %w", err)
+	}
+	defer stream.Close()
+	codec := ipc.NewCodec(stream)
+
+	const sequence = 1
+	if err := codec.Send(&wire.Envelope{Seq: sequence, Body: &wire.Envelope_Hello{Hello: &wire.Hello{
+		Abi: CurrentVersion, Runtime: "native-go/" + runtime.Version(),
+	}}}); err != nil {
+		return fmt.Errorf("pluginapi: send handshake: %w", err)
+	}
+	reply, err := codec.Receive()
+	if err != nil {
+		return fmt.Errorf("pluginapi: receive handshake: %w", err)
+	}
+	welcome := reply.GetWelcome()
+	if reply.GetSeq() != sequence || welcome == nil {
+		return fmt.Errorf("pluginapi: host answered HELLO with %T", reply.GetBody())
+	}
+	if welcome.GetAbi() != CurrentVersion {
+		return fmt.Errorf("pluginapi: host uses ABI %d, plugin uses %d", welcome.GetAbi(), CurrentVersion)
+	}
+	return serve(codec, newRuntimeState(metadata, implementation))
+}

--- a/pluginapi/runner_options.go
+++ b/pluginapi/runner_options.go
@@ -1,0 +1,48 @@
+package pluginapi
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type runnerOptions struct {
+	socket string
+	abi    uint
+}
+
+func parseRunnerOptions(arguments []string) (runnerOptions, error) {
+	var options runnerOptions
+	flags := flag.NewFlagSet("gocraft-go-plugin", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	flags.StringVar(&options.socket, "sock", "", "GoCraft IPC socket")
+	flags.UintVar(&options.abi, "abi", 0, "GoCraft ABI version")
+	if err := flags.Parse(arguments); err != nil {
+		return options, fmt.Errorf("pluginapi: parse runtime arguments: %w", err)
+	}
+	if strings.TrimSpace(options.socket) == "" {
+		return options, fmt.Errorf("pluginapi: --sock is required")
+	}
+	if options.abi != uint(CurrentVersion) {
+		return options, fmt.Errorf("pluginapi: host requested ABI %d, plugin uses %d", options.abi, CurrentVersion)
+	}
+	return options, nil
+}
+
+func validateMetadata(metadata Metadata, implementation Plugin) error {
+	if strings.TrimSpace(metadata.ID) == "" {
+		return fmt.Errorf("pluginapi: plugin id is required")
+	}
+	if strings.TrimSpace(metadata.Version) == "" {
+		return fmt.Errorf("pluginapi: plugin version is required")
+	}
+	if metadata.APIVersion != CurrentVersion {
+		return fmt.Errorf("pluginapi: plugin API %d is unsupported, runtime uses %d",
+			metadata.APIVersion, CurrentVersion)
+	}
+	if implementation == nil {
+		return fmt.Errorf("pluginapi: plugin implementation is required")
+	}
+	return nil
+}

--- a/pluginapi/runner_options_test.go
+++ b/pluginapi/runner_options_test.go
@@ -1,0 +1,40 @@
+package pluginapi
+
+import "testing"
+
+type noopPlugin struct{}
+
+func (*noopPlugin) OnLoad(Context) error { return nil }
+func (*noopPlugin) OnEnable() error      { return nil }
+func (*noopPlugin) OnDisable() error     { return nil }
+
+func TestParseRunnerOptions(t *testing.T) {
+	options, err := parseRunnerOptions([]string{"--sock", "runtime.sock", "--abi", "1"})
+	if err != nil || options.socket != "runtime.sock" || options.abi != 1 {
+		t.Fatalf("parseRunnerOptions() = %#v, %v", options, err)
+	}
+	for _, arguments := range [][]string{
+		{"--abi", "1"},
+		{"--sock", "runtime.sock", "--abi", "2"},
+		{"--unknown"},
+	} {
+		if _, err := parseRunnerOptions(arguments); err == nil {
+			t.Fatalf("parseRunnerOptions(%v) accepted invalid input", arguments)
+		}
+	}
+}
+
+func TestValidateMetadata(t *testing.T) {
+	valid := Metadata{ID: "example", Version: "1.0.0", APIVersion: CurrentVersion}
+	if err := validateMetadata(valid, &noopPlugin{}); err != nil {
+		t.Fatal(err)
+	}
+	invalid := valid
+	invalid.APIVersion++
+	if err := validateMetadata(invalid, &noopPlugin{}); err == nil {
+		t.Fatal("unsupported API version was accepted")
+	}
+	if err := validateMetadata(valid, nil); err == nil {
+		t.Fatal("nil plugin was accepted")
+	}
+}

--- a/pluginapi/scheduler.go
+++ b/pluginapi/scheduler.go
@@ -1,0 +1,74 @@
+package pluginapi
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"time"
+)
+
+type TaskID uint64
+
+// After runs a task once on its own goroutine after the delay.
+func (s *Scheduler) After(delay time.Duration, task func()) (TaskID, error) {
+	return s.schedule(delay, false, task)
+}
+
+// Every runs a task repeatedly on its own goroutine.
+func (s *Scheduler) Every(interval time.Duration, task func()) (TaskID, error) {
+	return s.schedule(interval, true, task)
+}
+
+func (s *Scheduler) schedule(delay time.Duration, repeat bool, task func()) (TaskID, error) {
+	if delay <= 0 || task == nil {
+		return 0, fmt.Errorf("pluginapi: task and positive duration are required")
+	}
+	s.mu.Lock()
+	if !s.active {
+		s.mu.Unlock()
+		return 0, fmt.Errorf("pluginapi: scheduler is disabled")
+	}
+	s.next++
+	id := s.next
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancels[id] = cancel
+	s.wait.Add(1)
+	s.mu.Unlock()
+	go s.run(ctx, id, delay, repeat, task)
+	return id, nil
+}
+
+func (s *Scheduler) run(ctx context.Context, id TaskID, delay time.Duration, repeat bool, task func()) {
+	defer s.wait.Done()
+	defer s.remove(id)
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			s.call(id, task)
+			if !repeat {
+				return
+			}
+			timer.Reset(delay)
+		}
+	}
+}
+
+func (s *Scheduler) remove(id TaskID) {
+	s.mu.Lock()
+	delete(s.cancels, id)
+	s.mu.Unlock()
+}
+
+func (s *Scheduler) call(id TaskID, task func()) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			s.logger.Error("plugin task panicked", "task", id,
+				"panic", recovered, "stack", string(debug.Stack()))
+		}
+	}()
+	task()
+}

--- a/pluginapi/scheduler.go
+++ b/pluginapi/scheduler.go
@@ -72,3 +72,32 @@ func (s *Scheduler) call(id TaskID, task func()) {
 	}()
 	task()
 }
+
+// Cancel stops an owned task. It reports whether the task was still active.
+func (s *Scheduler) Cancel(id TaskID) bool {
+	s.mu.Lock()
+	cancel, ok := s.cancels[id]
+	s.mu.Unlock()
+	if ok {
+		cancel()
+	}
+	return ok
+}
+
+func (s *Scheduler) stop() {
+	s.mu.Lock()
+	if !s.active {
+		s.mu.Unlock()
+		return
+	}
+	s.active = false
+	cancels := make([]context.CancelFunc, 0, len(s.cancels))
+	for _, cancel := range s.cancels {
+		cancels = append(cancels, cancel)
+	}
+	s.mu.Unlock()
+	for _, cancel := range cancels {
+		cancel()
+	}
+	s.wait.Wait()
+}

--- a/pluginapi/scheduler_test.go
+++ b/pluginapi/scheduler_test.go
@@ -1,0 +1,55 @@
+package pluginapi
+
+import (
+	"bytes"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSchedulerOwnsAndCancelsTasks(t *testing.T) {
+	scheduler := newScheduler(testLogger(&bytes.Buffer{}))
+	var calls atomic.Int32
+	ran := make(chan struct{}, 1)
+	id, err := scheduler.Every(time.Millisecond, func() {
+		calls.Add(1)
+		select {
+		case ran <- struct{}{}:
+		default:
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-ran
+	if !scheduler.Cancel(id) {
+		t.Fatal("active task was not cancelled")
+	}
+	scheduler.stop()
+	got := calls.Load()
+	time.Sleep(5 * time.Millisecond)
+	if calls.Load() != got {
+		t.Fatal("task ran after scheduler shutdown")
+	}
+	if _, err := scheduler.After(time.Millisecond, func() {}); err == nil {
+		t.Fatal("disabled scheduler accepted a task")
+	}
+}
+
+func TestSchedulerRecoversPanics(t *testing.T) {
+	var output bytes.Buffer
+	scheduler := newScheduler(testLogger(&output))
+	ran := make(chan struct{})
+	if _, err := scheduler.After(time.Millisecond, func() {
+		close(ran)
+		panic("task exploded")
+	}); err != nil {
+		t.Fatal(err)
+	}
+	<-ran
+	scheduler.stop()
+	if log := output.String(); !strings.Contains(log, "task exploded") || !strings.Contains(log, "stack") {
+		t.Fatalf("panic log = %q", log)
+	}
+}

--- a/pluginapi/session.go
+++ b/pluginapi/session.go
@@ -1,0 +1,56 @@
+package pluginapi
+
+import (
+	"fmt"
+	"io"
+
+	wire "GoCraft/abi/v1/wire"
+	"GoCraft/runtime/ipc"
+)
+
+func serve(codec *ipc.Codec, state *runtimeState) error {
+	session := &pluginSession{codec: codec, state: state}
+	work := make(chan *wire.Envelope, 8)
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		defer state.disable()
+		for envelope := range work {
+			session.handle(envelope)
+		}
+	}()
+	stop := func() {
+		close(work)
+		<-stopped
+	}
+	defer codec.Close()
+
+	for {
+		envelope, err := codec.Receive()
+		if err != nil {
+			stop()
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("pluginapi: receive host message: %w", err)
+		}
+		switch envelope.GetBody().(type) {
+		case *wire.Envelope_Ping:
+			if err := codec.Send(&wire.Envelope{Seq: envelope.GetSeq(),
+				Body: &wire.Envelope_Pong{Pong: &wire.Pong{}}}); err != nil {
+				stop()
+				return err
+			}
+		case *wire.Envelope_Ready:
+			// The host is now accepting players; no plugin callback is needed.
+		case *wire.Envelope_Shutdown:
+			stop()
+			return nil
+		case *wire.Envelope_Load, *wire.Envelope_Dispatch, *wire.Envelope_Unload:
+			work <- envelope
+		default:
+			stop()
+			return fmt.Errorf("pluginapi: unexpected host message %T", envelope.GetBody())
+		}
+	}
+}

--- a/pluginapi/session_handle.go
+++ b/pluginapi/session_handle.go
@@ -51,11 +51,20 @@ func (s *pluginSession) handleDispatch(seq uint64, dispatch *wire.Dispatch) {
 		err = &pluginIDError{expected: s.state.metadata.ID, got: dispatch.GetPluginId()}
 	}
 	if err == nil {
-		verdict, err = s.state.dispatch(event)
+		if event.Type == abi.EventCommandInvoke {
+			verdict, err = s.state.invokeCommand(event)
+		} else {
+			verdict, err = s.state.dispatch(event)
+		}
 	}
 	if err != nil {
 		if event != nil && event.OnFailure == abi.FailureDeny {
 			verdict.Cancelled = true
+		}
+		if event != nil && event.Type == abi.EventCommandInvoke {
+			verdict.Effects = append(verdict.Effects, abi.HostCall{
+				Type: abi.HostCallCommandFailed, Fields: []abi.Value{abi.String(err.Error())},
+			})
 		}
 		slog.Error("plugin event failed", "plugin", s.state.metadata.ID, "err", err)
 	}

--- a/pluginapi/session_handle.go
+++ b/pluginapi/session_handle.go
@@ -1,0 +1,80 @@
+package pluginapi
+
+import (
+	"log/slog"
+
+	abi "GoCraft/abi/v1"
+	wire "GoCraft/abi/v1/wire"
+	"GoCraft/runtime/ipc"
+)
+
+type pluginSession struct {
+	codec *ipc.Codec
+	state *runtimeState
+}
+
+func (s *pluginSession) handle(envelope *wire.Envelope) {
+	switch body := envelope.GetBody().(type) {
+	case *wire.Envelope_Load:
+		s.handleLoad(envelope.GetSeq(), body.Load)
+	case *wire.Envelope_Dispatch:
+		s.handleDispatch(envelope.GetSeq(), body.Dispatch)
+	case *wire.Envelope_Unload:
+		if body.Unload.GetPluginId() != s.state.metadata.ID {
+			slog.Error("plugin unload id mismatch", "plugin", s.state.metadata.ID,
+				"requested", body.Unload.GetPluginId())
+			return
+		}
+		if err := s.state.disable(); err != nil {
+			slog.Error("plugin disable failed", "plugin", s.state.metadata.ID, "err", err)
+		}
+	}
+}
+
+func (s *pluginSession) handleLoad(seq uint64, load *wire.Load) {
+	events, err := s.state.load(load.GetPluginId(), load.GetDataDirectory())
+	if err != nil {
+		s.send(&wire.Envelope{Seq: seq, Body: &wire.Envelope_Fail{Fail: &wire.Fail{
+			PluginId: load.GetPluginId(), Reason: err.Error(),
+		}}})
+		return
+	}
+	s.send(&wire.Envelope{Seq: seq, Body: &wire.Envelope_Loaded{Loaded: &wire.Loaded{
+		PluginId: load.GetPluginId(), Events: events,
+	}}})
+}
+
+func (s *pluginSession) handleDispatch(seq uint64, dispatch *wire.Dispatch) {
+	event, err := ipc.DecodeEvent(dispatch.GetEvent())
+	verdict := abi.Verdict{}
+	if err == nil && dispatch.GetPluginId() != s.state.metadata.ID {
+		err = &pluginIDError{expected: s.state.metadata.ID, got: dispatch.GetPluginId()}
+	}
+	if err == nil {
+		verdict, err = s.state.dispatch(event)
+	}
+	if err != nil {
+		if event != nil && event.OnFailure == abi.FailureDeny {
+			verdict.Cancelled = true
+		}
+		slog.Error("plugin event failed", "plugin", s.state.metadata.ID, "err", err)
+	}
+	encoded, encodeErr := ipc.EncodeVerdict(verdict)
+	if encodeErr != nil {
+		slog.Error("plugin verdict encoding failed", "plugin", s.state.metadata.ID, "err", encodeErr)
+		encoded = &wire.Verdict{Cancelled: verdict.Cancelled}
+	}
+	s.send(&wire.Envelope{Seq: seq, Body: &wire.Envelope_Verdict{Verdict: encoded}})
+}
+
+func (s *pluginSession) send(envelope *wire.Envelope) {
+	if err := s.codec.Send(envelope); err != nil {
+		slog.Error("plugin IPC send failed", "plugin", s.state.metadata.ID, "err", err)
+	}
+}
+
+type pluginIDError struct{ expected, got string }
+
+func (e *pluginIDError) Error() string {
+	return "pluginapi: dispatch id " + e.got + " does not match " + e.expected
+}

--- a/pluginapi/session_test.go
+++ b/pluginapi/session_test.go
@@ -1,0 +1,85 @@
+package pluginapi
+
+import (
+	"net"
+	"testing"
+
+	abi "GoCraft/abi/v1"
+	wire "GoCraft/abi/v1/wire"
+	"GoCraft/runtime/ipc"
+)
+
+type sessionPlugin struct {
+	entered  chan struct{}
+	release  chan struct{}
+	disabled int
+}
+
+func (p *sessionPlugin) OnLoad(context Context) error {
+	return context.Events().OnBlockBreak(func(event *BlockBreakEvent) {
+		close(p.entered)
+		<-p.release
+		event.Cancel()
+	})
+}
+
+func (*sessionPlugin) OnEnable() error { return nil }
+func (p *sessionPlugin) OnDisable() error {
+	p.disabled++
+	return nil
+}
+
+func TestSessionKeepsHeartbeatResponsiveDuringEvent(t *testing.T) {
+	hostStream, childStream := net.Pipe()
+	host := ipc.NewCodec(hostStream)
+	implementation := &sessionPlugin{entered: make(chan struct{}), release: make(chan struct{})}
+	state := newRuntimeState(Metadata{ID: "example"}, implementation)
+	result := make(chan error, 1)
+	go func() { result <- serve(ipc.NewCodec(childStream), state) }()
+
+	if err := host.Send(&wire.Envelope{Seq: 1, Body: &wire.Envelope_Load{Load: &wire.Load{
+		PluginId: "example", DataDirectory: "data",
+	}}}); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := host.Receive()
+	if err != nil || loaded.GetLoaded() == nil || len(loaded.GetLoaded().GetEvents()) != 1 {
+		t.Fatalf("LOAD response = %#v, %v", loaded, err)
+	}
+	event, err := ipc.EncodeEvent(testBlockBreakABI())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := host.Send(&wire.Envelope{Seq: 2, Body: &wire.Envelope_Dispatch{Dispatch: &wire.Dispatch{
+		PluginId: "example", Event: event,
+	}}}); err != nil {
+		t.Fatal(err)
+	}
+	<-implementation.entered
+	if err := host.Send(&wire.Envelope{Seq: 3, Body: &wire.Envelope_Ping{Ping: &wire.Ping{}}}); err != nil {
+		t.Fatal(err)
+	}
+	pong, err := host.Receive()
+	if err != nil || pong.GetSeq() != 3 || pong.GetPong() == nil {
+		t.Fatalf("PING response = %#v, %v", pong, err)
+	}
+	close(implementation.release)
+	verdict, err := host.Receive()
+	if err != nil || verdict.GetSeq() != 2 || !verdict.GetVerdict().GetCancelled() {
+		t.Fatalf("DISPATCH response = %#v, %v", verdict, err)
+	}
+	if err := host.Send(&wire.Envelope{Body: &wire.Envelope_Shutdown{Shutdown: &wire.Shutdown{}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-result; err != nil || implementation.disabled != 1 {
+		t.Fatalf("serve() = %v, disabled=%d", err, implementation.disabled)
+	}
+}
+
+func testBlockBreakABI() *abi.Event {
+	player := abi.List(abi.Bytes(make([]byte, 16)), abi.String("Elias"), abi.String("java"))
+	return &abi.Event{Type: EventBlockBreak, OnFailure: abi.FailureAllow, Fields: []abi.Value{
+		player, abi.List(abi.Int64(1), abi.Int64(64), abi.Int64(2)),
+		abi.List(abi.String("minecraft:stone"), abi.List()), abi.String("minecraft:pickaxe"), abi.List(),
+	}}
+}

--- a/pluginapi/wire_helpers.go
+++ b/pluginapi/wire_helpers.go
@@ -1,0 +1,66 @@
+package pluginapi
+
+import (
+	"fmt"
+
+	abi "GoCraft/abi/v1"
+)
+
+func listOf(value abi.Value, length int, name string) ([]abi.Value, error) {
+	if value.Kind != abi.ValueList || len(value.List) != length {
+		return nil, fmt.Errorf("pluginapi: %s must contain %d values", name, length)
+	}
+	return value.List, nil
+}
+
+func stringFrom(value abi.Value, name string) (string, error) {
+	if value.Kind != abi.ValueString {
+		return "", fmt.Errorf("pluginapi: %s is not a string", name)
+	}
+	return value.String, nil
+}
+
+func permissionsFrom(value abi.Value) (map[string]bool, error) {
+	if value.Kind != abi.ValueList {
+		return nil, fmt.Errorf("pluginapi: permissions are not a list")
+	}
+	permissions := make(map[string]bool, len(value.List))
+	for _, entry := range value.List {
+		pair, err := listOf(entry, 2, "permission")
+		if err != nil {
+			return nil, err
+		}
+		node, err := stringFrom(pair[0], "permission node")
+		if err != nil {
+			return nil, err
+		}
+		if pair[1].Kind != abi.ValueBool {
+			return nil, fmt.Errorf("pluginapi: permission %s is not boolean", node)
+		}
+		permissions[node] = pair[1].Bool
+	}
+	return permissions, nil
+}
+
+func propertiesFrom(value abi.Value) (map[string]string, error) {
+	if value.Kind != abi.ValueList {
+		return nil, fmt.Errorf("pluginapi: block properties are not a list")
+	}
+	properties := make(map[string]string, len(value.List))
+	for _, entry := range value.List {
+		pair, err := listOf(entry, 2, "block property")
+		if err != nil {
+			return nil, err
+		}
+		key, err := stringFrom(pair[0], "block property name")
+		if err != nil {
+			return nil, err
+		}
+		property, err := stringFrom(pair[1], "block property value")
+		if err != nil {
+			return nil, err
+		}
+		properties[key] = property
+	}
+	return properties, nil
+}

--- a/pluginapi/wire_values.go
+++ b/pluginapi/wire_values.go
@@ -1,0 +1,58 @@
+package pluginapi
+
+import (
+	"fmt"
+
+	abi "GoCraft/abi/v1"
+)
+
+func playerFrom(value abi.Value) (Player, error) {
+	items, err := listOf(value, 3, "player")
+	if err != nil {
+		return Player{}, err
+	}
+	if items[0].Kind != abi.ValueBytes || len(items[0].Bytes) != 16 {
+		return Player{}, fmt.Errorf("pluginapi: player uuid is not 16 bytes")
+	}
+	username, err := stringFrom(items[1], "player username")
+	if err != nil {
+		return Player{}, err
+	}
+	edition, err := stringFrom(items[2], "player edition")
+	if err != nil {
+		return Player{}, err
+	}
+	var player Player
+	copy(player.UUID[:], items[0].Bytes)
+	player.Username, player.Edition = username, edition
+	return player, nil
+}
+
+func positionFrom(value abi.Value) (BlockPos, error) {
+	items, err := listOf(value, 3, "block position")
+	if err != nil {
+		return BlockPos{}, err
+	}
+	for _, item := range items {
+		if item.Kind != abi.ValueInt64 {
+			return BlockPos{}, fmt.Errorf("pluginapi: block position coordinate is not an integer")
+		}
+	}
+	return BlockPos{X: int32(items[0].Int64), Y: int32(items[1].Int64), Z: int32(items[2].Int64)}, nil
+}
+
+func blockFrom(value abi.Value) (Block, error) {
+	items, err := listOf(value, 2, "block")
+	if err != nil {
+		return Block{}, err
+	}
+	id, err := stringFrom(items[0], "block id")
+	if err != nil {
+		return Block{}, err
+	}
+	properties, err := propertiesFrom(items[1])
+	if err != nil {
+		return Block{}, err
+	}
+	return Block{ID: id, Properties: properties}, nil
+}

--- a/pluginapi/wire_values_test.go
+++ b/pluginapi/wire_values_test.go
@@ -1,0 +1,33 @@
+package pluginapi
+
+import (
+	"testing"
+
+	abi "GoCraft/abi/v1"
+)
+
+func TestWireVocabularyDecoding(t *testing.T) {
+	uuid := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	player, err := playerFrom(abi.List(abi.Bytes(uuid), abi.String("Elias"), abi.String("bedrock")))
+	if err != nil || player.Username != "Elias" || player.Edition != "bedrock" || player.UUID[15] != 16 {
+		t.Fatalf("playerFrom() = %#v, %v", player, err)
+	}
+	position, err := positionFrom(abi.List(abi.Int64(12), abi.Int64(64), abi.Int64(-8)))
+	if err != nil || position != (BlockPos{X: 12, Y: 64, Z: -8}) {
+		t.Fatalf("positionFrom() = %#v, %v", position, err)
+	}
+	block, err := blockFrom(abi.List(abi.String("minecraft:stone"),
+		abi.List(abi.List(abi.String("variant"), abi.String("smooth")))))
+	if err != nil || block.ID != "minecraft:stone" || block.Properties["variant"] != "smooth" {
+		t.Fatalf("blockFrom() = %#v, %v", block, err)
+	}
+}
+
+func TestWireVocabularyRejectsMalformedValues(t *testing.T) {
+	if _, err := playerFrom(abi.List()); err == nil {
+		t.Fatal("malformed player was accepted")
+	}
+	if _, err := permissionsFrom(abi.String("admin")); err == nil {
+		t.Fatal("malformed permissions were accepted")
+	}
+}

--- a/runtime/goplugin/command.go
+++ b/runtime/goplugin/command.go
@@ -1,0 +1,43 @@
+package goplugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	abi "GoCraft/abi/v1"
+	"GoCraft/core/command"
+)
+
+func (i *Instance) InvokeCommand(ctx context.Context, executor command.ExecID,
+	sender command.Sender, values command.Values) error {
+	if sender == nil {
+		return fmt.Errorf("go runtime: command sender is required")
+	}
+	event, err := commandEvent(executor, sender, values)
+	if err != nil {
+		return err
+	}
+	verdict, err := i.supervisor.Dispatch(ctx, i.manifest.ID, event)
+	if err != nil {
+		return err
+	}
+	var joined error
+	for _, effect := range verdict.Effects {
+		if len(effect.Fields) != 1 || effect.Fields[0].Kind != abi.ValueString {
+			joined = errors.Join(joined, fmt.Errorf("go runtime: malformed command result %s", effect.Type))
+			continue
+		}
+		switch effect.Type {
+		case abi.HostCallCommandReply:
+			if err := sender.SendMessage(effect.Fields[0].String); err != nil {
+				joined = errors.Join(joined, err)
+			}
+		case abi.HostCallCommandFailed:
+			joined = errors.Join(joined, errors.New(effect.Fields[0].String))
+		default:
+			joined = errors.Join(joined, fmt.Errorf("go runtime: unknown command result %s", effect.Type))
+		}
+	}
+	return joined
+}

--- a/runtime/goplugin/command_encode.go
+++ b/runtime/goplugin/command_encode.go
@@ -1,0 +1,69 @@
+package goplugin
+
+import (
+	"fmt"
+	"sort"
+
+	abi "GoCraft/abi/v1"
+	"GoCraft/core/command"
+)
+
+func commandEvent(executor command.ExecID, sender command.Sender, values command.Values) (*abi.Event, error) {
+	playerRef, _ := sender.Player()
+	arguments, err := commandArguments(values)
+	if err != nil {
+		return nil, err
+	}
+	return &abi.Event{
+		Type:      abi.EventCommandInvoke,
+		OnFailure: abi.FailureAllow,
+		Fields: []abi.Value{
+			abi.Int64(int64(executor)),
+			playerValue(playerRef),
+			abi.String(sender.Name()),
+			abi.List(arguments...),
+		},
+	}, nil
+}
+
+func commandArguments(values command.Values) ([]abi.Value, error) {
+	names := make([]string, 0, len(values))
+	for name := range values {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	arguments := make([]abi.Value, 0, len(names))
+	for _, name := range names {
+		value := values[name]
+		encoded, err := commandArgument(value)
+		if err != nil {
+			return nil, fmt.Errorf("command argument %s: %w", name, err)
+		}
+		arguments = append(arguments, abi.List(
+			abi.String(name), abi.Int64(int64(value.Type)), encoded))
+	}
+	return arguments, nil
+}
+
+func commandArgument(value command.Value) (abi.Value, error) {
+	switch value.Type {
+	case command.ArgInteger:
+		return abi.Int64(value.Integer), nil
+	case command.ArgDecimal:
+		return abi.Double(value.Decimal), nil
+	case command.ArgString, command.ArgGreedy, command.ArgEnum, command.ArgCustom:
+		return abi.String(value.String), nil
+	case command.ArgPlayer:
+		return playerValue(value.Player), nil
+	case command.ArgBlockPos:
+		return positionValue(value.Position), nil
+	case command.ArgBlockState:
+		return blockValue(value.Block), nil
+	case command.ArgItem:
+		return abi.String(value.Item.ItemID), nil
+	case command.ArgDuration:
+		return abi.Int64(int64(value.Duration)), nil
+	default:
+		return abi.Value{}, fmt.Errorf("unsupported type %d", value.Type)
+	}
+}

--- a/runtime/goplugin/encode_values.go
+++ b/runtime/goplugin/encode_values.go
@@ -1,0 +1,43 @@
+package goplugin
+
+import (
+	"sort"
+
+	abi "GoCraft/abi/v1"
+	"GoCraft/core/player"
+	"GoCraft/core/spatial"
+	coreworld "GoCraft/core/world"
+)
+
+func playerValue(value *player.Player) abi.Value {
+	if value == nil {
+		return abi.List()
+	}
+	edition := "java"
+	if value.Edition == player.ClientEditionBedrock {
+		edition = "bedrock"
+	}
+	return abi.List(abi.Bytes(value.UUID[:]), abi.String(value.Username), abi.String(edition))
+}
+
+func positionValue(value spatial.BlockPos) abi.Value {
+	return abi.List(
+		abi.Int64(int64(value.X)),
+		abi.Int64(int64(value.Y)),
+		abi.Int64(int64(value.Z)),
+	)
+}
+
+func blockValue(value coreworld.Block) abi.Value {
+	keys := make([]string, 0, len(value.Properties))
+	for key := range value.Properties {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	properties := make([]abi.Value, 0, len(keys))
+	for _, key := range keys {
+		properties = append(properties,
+			abi.List(abi.String(key), abi.String(value.Properties[key])))
+	}
+	return abi.List(abi.String(value.ResourceLocation()), abi.List(properties...))
+}

--- a/runtime/goplugin/extract.go
+++ b/runtime/goplugin/extract.go
@@ -1,0 +1,86 @@
+package goplugin
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"GoCraft/core/plugin"
+)
+
+const maximumExecutableSize = 256 << 20
+
+func (r *Runtime) extract(bundle plugin.Bundle) (string, func(), error) {
+	entry := bundle.Manifest.Entry
+	if !validEntry(entry) {
+		return "", nil, fmt.Errorf("go runtime: plugin %s has invalid entry %q", bundle.Manifest.ID, entry)
+	}
+	archive, err := zip.OpenReader(bundle.Path)
+	if err != nil {
+		return "", nil, fmt.Errorf("go runtime: open bundle: %w", err)
+	}
+	defer archive.Close()
+	var source *zip.File
+	for _, file := range archive.File {
+		name := path.Clean(strings.ReplaceAll(file.Name, "\\", "/"))
+		if name == entry {
+			if source != nil {
+				return "", nil, fmt.Errorf("go runtime: duplicate entry %s", entry)
+			}
+			source = file
+		}
+	}
+	if source == nil || source.FileInfo().IsDir() {
+		return "", nil, fmt.Errorf("go runtime: bundle is missing executable %s", entry)
+	}
+	if source.UncompressedSize64 > maximumExecutableSize {
+		return "", nil, fmt.Errorf("go runtime: executable exceeds %d bytes", maximumExecutableSize)
+	}
+	directory, err := os.MkdirTemp(r.config.ExtractDirectory, "gocraft-go-")
+	if err != nil {
+		return "", nil, fmt.Errorf("go runtime: create extraction directory: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(directory) }
+	target := filepath.Join(directory, "plugin"+filepath.Ext(entry))
+	if err := copyExecutable(source, target); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return target, cleanup, nil
+}
+
+func copyExecutable(source *zip.File, target string) error {
+	reader, err := source.Open()
+	if err != nil {
+		return fmt.Errorf("go runtime: open executable: %w", err)
+	}
+	defer reader.Close()
+	output, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o700)
+	if err != nil {
+		return fmt.Errorf("go runtime: create executable: %w", err)
+	}
+	written, copyErr := io.Copy(output, io.LimitReader(reader, maximumExecutableSize+1))
+	closeErr := output.Close()
+	if copyErr != nil {
+		return fmt.Errorf("go runtime: extract executable: %w", copyErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("go runtime: close executable: %w", closeErr)
+	}
+	if written > maximumExecutableSize {
+		return fmt.Errorf("go runtime: executable expanded beyond its size limit")
+	}
+	return nil
+}
+
+func validEntry(entry string) bool {
+	if entry == "" || strings.Contains(entry, `\`) || path.IsAbs(entry) {
+		return false
+	}
+	cleaned := path.Clean(entry)
+	return cleaned == entry && cleaned != "." && cleaned != ".." && !strings.HasPrefix(cleaned, "../")
+}

--- a/runtime/goplugin/extract_test.go
+++ b/runtime/goplugin/extract_test.go
@@ -1,0 +1,64 @@
+package goplugin
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"GoCraft/core/plugin"
+)
+
+func TestExtractExecutableAndCleanup(t *testing.T) {
+	bundlePath := writeTestBundle(t, "bin/example", []byte("native plugin"))
+	runtime := New(Config{ExtractDirectory: t.TempDir()})
+	bundle := plugin.Bundle{Path: bundlePath, Manifest: plugin.Manifest{ID: "example", Entry: "bin/example"}}
+	executable, cleanup, err := runtime.extract(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(executable)
+	if err != nil || string(data) != "native plugin" {
+		t.Fatalf("extracted executable = %q, %v", data, err)
+	}
+	directory := filepath.Dir(executable)
+	cleanup()
+	if _, err := os.Stat(directory); !os.IsNotExist(err) {
+		t.Fatalf("cleanup left directory: %v", err)
+	}
+}
+
+func TestExtractRejectsUnsafeOrMissingEntry(t *testing.T) {
+	bundlePath := writeTestBundle(t, "bin/example", []byte("plugin"))
+	runtime := New(Config{ExtractDirectory: t.TempDir()})
+	for _, entry := range []string{"", "../example", `bin\example`, "bin/missing"} {
+		bundle := plugin.Bundle{Path: bundlePath, Manifest: plugin.Manifest{ID: "example", Entry: entry}}
+		if _, _, err := runtime.extract(bundle); err == nil {
+			t.Fatalf("entry %q was accepted", entry)
+		}
+	}
+}
+
+func writeTestBundle(t *testing.T, entry string, content []byte) string {
+	t.Helper()
+	name := filepath.Join(t.TempDir(), "example.gcpkg")
+	file, err := os.Create(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive := zip.NewWriter(file)
+	writer, err := archive.Create(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return name
+}

--- a/runtime/goplugin/failure_test.go
+++ b/runtime/goplugin/failure_test.go
@@ -1,0 +1,48 @@
+package goplugin
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"GoCraft/core/plugin"
+	"GoCraft/runtime/ipc"
+)
+
+func TestRuntimeCleansUpPluginFailures(t *testing.T) {
+	for _, phase := range []string{"load", "enable"} {
+		t.Run(phase, func(t *testing.T) {
+			extractDirectory := t.TempDir()
+			socketDirectory, err := os.MkdirTemp("", "gc-go-fail-")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(socketDirectory)
+			runtime := New(Config{
+				ExtractDirectory: extractDirectory, SocketDirectory: socketDirectory,
+				StartTimeout: 3 * time.Second,
+				Spawn:        func(string) ipc.Spawn { return helperSpawnFailure(phase) },
+			})
+			if err := runtime.Start(t.Context(), nil); err != nil {
+				t.Fatal(err)
+			}
+			bundle := plugin.Bundle{
+				Path:          writeTestBundle(t, "bin/example", []byte("placeholder")),
+				DataDirectory: t.TempDir(),
+				Manifest:      plugin.Manifest{ID: "example", Entry: "bin/example"},
+			}
+			if _, err := runtime.Load(t.Context(), bundle); err == nil ||
+				!strings.Contains(err.Error(), phase+" failure") {
+				t.Fatalf("Load() error = %v", err)
+			}
+			entries, err := os.ReadDir(extractDirectory)
+			if err != nil || len(entries) != 0 {
+				t.Fatalf("extraction leftovers = %v, %v", entries, err)
+			}
+			if err := runtime.Stop(t.Context()); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/runtime/goplugin/helper_process_test.go
+++ b/runtime/goplugin/helper_process_test.go
@@ -1,0 +1,64 @@
+package goplugin
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"GoCraft/pluginapi"
+	"GoCraft/runtime/ipc"
+)
+
+type helperPlugin struct{}
+
+func (*helperPlugin) OnLoad(context pluginapi.Context) error {
+	if err := context.Events().OnBlockBreak(func(event *pluginapi.BlockBreakEvent) {
+		event.Cancel()
+	}); err != nil {
+		return err
+	}
+	return context.Commands().Register(7, func(call *pluginapi.CommandContext) error {
+		value, ok := call.Args.Integer("amount")
+		if !ok {
+			return fmt.Errorf("amount is missing")
+		}
+		call.Reply(fmt.Sprintf("amount=%d", value))
+		return nil
+	})
+}
+
+func (*helperPlugin) OnEnable() error  { return nil }
+func (*helperPlugin) OnDisable() error { return nil }
+
+func TestNativePluginHelperProcess(t *testing.T) {
+	if os.Getenv("GOCRAFT_NATIVE_PLUGIN_HELPER") != "1" {
+		return
+	}
+	separator := 0
+	for index, argument := range os.Args {
+		if argument == "--" {
+			separator = index
+			break
+		}
+	}
+	os.Args = append([]string{os.Args[0]}, os.Args[separator+1:]...)
+	err := pluginapi.Run(pluginapi.Metadata{
+		ID: "example", Version: "1.0.0", APIVersion: pluginapi.CurrentVersion,
+	}, &helperPlugin{})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
+
+func helperSpawn(string) ipc.Spawn {
+	return func(socket string) *exec.Cmd {
+		command := exec.Command(os.Args[0],
+			"-test.run=TestNativePluginHelperProcess", "--",
+			"--sock", socket, "--abi", "1")
+		command.Env = append(os.Environ(), "GOCRAFT_NATIVE_PLUGIN_HELPER=1")
+		return command
+	}
+}

--- a/runtime/goplugin/helper_process_test.go
+++ b/runtime/goplugin/helper_process_test.go
@@ -1,6 +1,7 @@
 package goplugin
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,6 +14,9 @@ import (
 type helperPlugin struct{}
 
 func (*helperPlugin) OnLoad(context pluginapi.Context) error {
+	if os.Getenv("GOCRAFT_NATIVE_PLUGIN_FAILURE") == "load" {
+		return errors.New("load failure")
+	}
 	if err := context.Events().OnBlockBreak(func(event *pluginapi.BlockBreakEvent) {
 		event.Cancel()
 	}); err != nil {
@@ -28,7 +32,12 @@ func (*helperPlugin) OnLoad(context pluginapi.Context) error {
 	})
 }
 
-func (*helperPlugin) OnEnable() error  { return nil }
+func (*helperPlugin) OnEnable() error {
+	if os.Getenv("GOCRAFT_NATIVE_PLUGIN_FAILURE") == "enable" {
+		return errors.New("enable failure")
+	}
+	return nil
+}
 func (*helperPlugin) OnDisable() error { return nil }
 
 func TestNativePluginHelperProcess(t *testing.T) {
@@ -54,11 +63,16 @@ func TestNativePluginHelperProcess(t *testing.T) {
 }
 
 func helperSpawn(string) ipc.Spawn {
+	return helperSpawnFailure("")
+}
+
+func helperSpawnFailure(failure string) ipc.Spawn {
 	return func(socket string) *exec.Cmd {
 		command := exec.Command(os.Args[0],
 			"-test.run=TestNativePluginHelperProcess", "--",
 			"--sock", socket, "--abi", "1")
-		command.Env = append(os.Environ(), "GOCRAFT_NATIVE_PLUGIN_HELPER=1")
+		command.Env = append(os.Environ(), "GOCRAFT_NATIVE_PLUGIN_HELPER=1",
+			"GOCRAFT_NATIVE_PLUGIN_FAILURE="+failure)
 		return command
 	}
 }

--- a/runtime/goplugin/instance.go
+++ b/runtime/goplugin/instance.go
@@ -1,10 +1,20 @@
 package goplugin
 
-import "GoCraft/core/plugin"
+import (
+	"sync"
+
+	"GoCraft/core/plugin"
+	"GoCraft/runtime/ipc"
+)
 
 // Instance is one native plugin process.
 type Instance struct {
-	manifest plugin.Manifest
+	runtime    *Runtime
+	manifest   plugin.Manifest
+	supervisor *ipc.Supervisor
+	cleanup    func()
+	unloadOnce sync.Once
+	unloadErr  error
 }
 
 func (i *Instance) Manifest() plugin.Manifest { return i.manifest }

--- a/runtime/goplugin/instance.go
+++ b/runtime/goplugin/instance.go
@@ -1,8 +1,11 @@
 package goplugin
 
 import (
+	"context"
+	"errors"
 	"sync"
 
+	abi "GoCraft/abi/v1"
 	"GoCraft/core/plugin"
 	"GoCraft/runtime/ipc"
 )
@@ -18,3 +21,20 @@ type Instance struct {
 }
 
 func (i *Instance) Manifest() plugin.Manifest { return i.manifest }
+
+func (i *Instance) Dispatch(ctx context.Context, event *abi.Event) (abi.Verdict, error) {
+	return i.supervisor.Dispatch(ctx, i.manifest.ID, event)
+}
+
+func (i *Instance) Unload(ctx context.Context) error {
+	i.unloadOnce.Do(func() {
+		unloadErr := i.supervisor.Unload(i.manifest.ID)
+		stopErr := i.supervisor.Stop(ctx)
+		if i.cleanup != nil {
+			i.cleanup()
+		}
+		i.runtime.remove(i.manifest.ID)
+		i.unloadErr = errors.Join(unloadErr, stopErr)
+	})
+	return i.unloadErr
+}

--- a/runtime/goplugin/instance.go
+++ b/runtime/goplugin/instance.go
@@ -1,0 +1,10 @@
+package goplugin
+
+import "GoCraft/core/plugin"
+
+// Instance is one native plugin process.
+type Instance struct {
+	manifest plugin.Manifest
+}
+
+func (i *Instance) Manifest() plugin.Manifest { return i.manifest }

--- a/runtime/goplugin/load.go
+++ b/runtime/goplugin/load.go
@@ -1,0 +1,57 @@
+package goplugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"GoCraft/core/plugin"
+	"GoCraft/runtime/ipc"
+)
+
+func (r *Runtime) Load(ctx context.Context, bundle plugin.Bundle) (plugin.Instance, error) {
+	if !r.isStarted() {
+		return nil, fmt.Errorf("go runtime: not started")
+	}
+	executable, cleanup, err := r.extract(bundle)
+	if err != nil {
+		return nil, err
+	}
+	supervisor := r.newSupervisor(bundle.Manifest.ID, executable)
+	if err := supervisor.Start(ctx); err != nil {
+		cleanup()
+		return nil, err
+	}
+	events := make([]string, 0, len(bundle.Manifest.Subscriptions))
+	for _, subscription := range bundle.Manifest.Subscriptions {
+		events = append(events, subscription.Event)
+	}
+	_, err = supervisor.Load(ctx, ipc.LoadRequest{
+		ID:            bundle.Manifest.ID,
+		BundlePath:    bundle.Path,
+		Entry:         bundle.Manifest.Entry,
+		DataDirectory: bundle.DataDirectory,
+		Events:        events,
+	})
+	if err != nil {
+		stopErr := supervisor.Stop(ctx)
+		cleanup()
+		return nil, errors.Join(err, stopErr)
+	}
+	instance := &Instance{
+		runtime: r, manifest: bundle.Manifest,
+		supervisor: supervisor, cleanup: cleanup,
+	}
+	if err := r.add(instance); err != nil {
+		stopErr := supervisor.Stop(ctx)
+		cleanup()
+		return nil, errors.Join(err, stopErr)
+	}
+	return instance, nil
+}
+
+func (r *Runtime) isStarted() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.started
+}

--- a/runtime/goplugin/runtime.go
+++ b/runtime/goplugin/runtime.go
@@ -26,6 +26,8 @@ type Config struct {
 	Liveness         ipc.Liveness
 	Stdout           io.Writer
 	Stderr           io.Writer
+	// Spawn replaces process creation in tests.
+	Spawn func(executable string) ipc.Spawn
 }
 
 type Runtime struct {

--- a/runtime/goplugin/runtime.go
+++ b/runtime/goplugin/runtime.go
@@ -1,0 +1,75 @@
+// Package goplugin runs compiled GoCraft plugins in isolated child processes.
+package goplugin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"GoCraft/core/plugin"
+	"GoCraft/runtime/ipc"
+)
+
+const (
+	RuntimeName = "go"
+	abiVersion  = 1
+)
+
+type Config struct {
+	ExtractDirectory string
+	SocketDirectory  string
+	TickRate         uint32
+	EventBudget      time.Duration
+	StartTimeout     time.Duration
+	Liveness         ipc.Liveness
+	Stdout           io.Writer
+	Stderr           io.Writer
+}
+
+type Runtime struct {
+	config Config
+
+	mu        sync.Mutex
+	started   bool
+	instances map[string]*Instance
+}
+
+func New(config Config) *Runtime {
+	return &Runtime{config: config, instances: make(map[string]*Instance)}
+}
+
+func (*Runtime) Name() string { return RuntimeName }
+
+// Provision is intentionally empty: a native plugin carries its own runtime.
+func (*Runtime) Provision(context.Context, plugin.Provisioner) error { return nil }
+
+func (r *Runtime) Start(context.Context, plugin.Host) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.started {
+		return fmt.Errorf("go runtime: already started")
+	}
+	r.started = true
+	return nil
+}
+
+func (r *Runtime) add(instance *Instance) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.started {
+		return fmt.Errorf("go runtime: not started")
+	}
+	if _, exists := r.instances[instance.manifest.ID]; exists {
+		return fmt.Errorf("go runtime: plugin %s is already loaded", instance.manifest.ID)
+	}
+	r.instances[instance.manifest.ID] = instance
+	return nil
+}
+
+func (r *Runtime) remove(id string) {
+	r.mu.Lock()
+	delete(r.instances, id)
+	r.mu.Unlock()
+}

--- a/runtime/goplugin/runtime_test.go
+++ b/runtime/goplugin/runtime_test.go
@@ -1,0 +1,83 @@
+package goplugin
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	abi "GoCraft/abi/v1"
+	"GoCraft/core/command"
+	"GoCraft/core/player"
+	"GoCraft/core/plugin"
+)
+
+type testSender struct{ messages []string }
+
+func (*testSender) Name() string                   { return "Console" }
+func (*testSender) UUID() [16]byte                 { return [16]byte{} }
+func (*testSender) Has(string) bool                { return true }
+func (*testSender) Player() (*player.Player, bool) { return nil, false }
+func (s *testSender) SendMessage(message string) error {
+	s.messages = append(s.messages, message)
+	return nil
+}
+
+func TestRuntimeLoadsDispatchesCommandsAndStops(t *testing.T) {
+	socketDirectory, err := os.MkdirTemp("", "gc-go-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(socketDirectory)
+	runtime := New(Config{
+		ExtractDirectory: t.TempDir(), SocketDirectory: socketDirectory,
+		StartTimeout: 3 * time.Second, Spawn: helperSpawn,
+	})
+	if err := runtime.Start(t.Context(), nil); err != nil {
+		t.Fatal(err)
+	}
+	bundle := plugin.Bundle{
+		Path:          writeTestBundle(t, "bin/example", []byte("placeholder")),
+		DataDirectory: t.TempDir(),
+		Manifest: plugin.Manifest{
+			ID: "example", Version: "1.0.0", APIVersion: 1,
+			Runtime: RuntimeName, Entry: "bin/example",
+			Subscriptions: []plugin.Subscription{{Event: "block.break"}},
+		},
+	}
+	loaded, err := runtime.Load(t.Context(), bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runtime.Ready(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	verdict, err := loaded.Dispatch(t.Context(), runtimeBlockBreakEvent())
+	if err != nil || !verdict.Cancelled {
+		t.Fatalf("Dispatch() = %#v, %v", verdict, err)
+	}
+	sender := &testSender{}
+	commands := loaded.(plugin.CommandInstance)
+	if err := commands.InvokeCommand(t.Context(), 7, sender, command.Values{
+		"amount": {Type: command.ArgInteger, Integer: 4},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(sender.messages) != 1 || sender.messages[0] != "amount=4" {
+		t.Fatalf("command messages = %v", sender.messages)
+	}
+	if err := loaded.Unload(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if err := runtime.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runtimeBlockBreakEvent() *abi.Event {
+	actor := abi.List(abi.Bytes(make([]byte, 16)), abi.String("Elias"), abi.String("java"))
+	return &abi.Event{Type: "block.break", OnFailure: abi.FailureAllow, Fields: []abi.Value{
+		actor, abi.List(abi.Int64(1), abi.Int64(64), abi.Int64(2)),
+		abi.List(abi.String("minecraft:stone"), abi.List()), abi.String("minecraft:pickaxe"), abi.List(),
+	}}
+}

--- a/runtime/goplugin/shutdown.go
+++ b/runtime/goplugin/shutdown.go
@@ -1,0 +1,53 @@
+package goplugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+)
+
+func (r *Runtime) Ready(context.Context) error {
+	instances := r.snapshot()
+	for _, instance := range instances {
+		if err := instance.supervisor.Ready(); err != nil {
+			return fmt.Errorf("go runtime: ready plugin %s: %w", instance.manifest.ID, err)
+		}
+	}
+	return nil
+}
+
+func (r *Runtime) Stop(ctx context.Context) error {
+	r.mu.Lock()
+	instances := orderedInstances(r.instances)
+	r.instances = make(map[string]*Instance)
+	r.started = false
+	r.mu.Unlock()
+	var joined error
+	for index := len(instances) - 1; index >= 0; index-- {
+		if err := instances[index].Unload(ctx); err != nil {
+			joined = errors.Join(joined, fmt.Errorf("plugin %s: %w",
+				instances[index].manifest.ID, err))
+		}
+	}
+	return joined
+}
+
+func (r *Runtime) snapshot() []*Instance {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return orderedInstances(r.instances)
+}
+
+func orderedInstances(instances map[string]*Instance) []*Instance {
+	ids := make([]string, 0, len(instances))
+	for id := range instances {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	ordered := make([]*Instance, 0, len(ids))
+	for _, id := range ids {
+		ordered = append(ordered, instances[id])
+	}
+	return ordered
+}

--- a/runtime/goplugin/supervisor.go
+++ b/runtime/goplugin/supervisor.go
@@ -1,0 +1,54 @@
+package goplugin
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"GoCraft/runtime/ipc"
+)
+
+func (r *Runtime) newSupervisor(pluginID, executable string) *ipc.Supervisor {
+	spawn := r.spawn(executable)
+	directory := r.config.SocketDirectory
+	if directory == "" {
+		directory = os.TempDir()
+	}
+	return ipc.NewSupervisor(ipc.Config{
+		Runtime:      runtimeLabel(pluginID),
+		Directory:    directory,
+		ABI:          abiVersion,
+		TickRate:     r.config.TickRate,
+		EventBudget:  r.config.EventBudget,
+		StartTimeout: r.config.StartTimeout,
+		Spawn:        spawn,
+	}, r.config.Liveness)
+}
+
+func (r *Runtime) spawn(executable string) ipc.Spawn {
+	if r.config.Spawn != nil {
+		return r.config.Spawn(executable)
+	}
+	return func(socket string) *exec.Cmd {
+		command := exec.Command(executable,
+			"--sock", socket,
+			"--abi", strconv.Itoa(abiVersion),
+		)
+		command.Stdout = r.config.Stdout
+		if command.Stdout == nil {
+			command.Stdout = os.Stdout
+		}
+		command.Stderr = r.config.Stderr
+		if command.Stderr == nil {
+			command.Stderr = os.Stderr
+		}
+		return command
+	}
+}
+
+func runtimeLabel(pluginID string) string {
+	hash := sha256.Sum256([]byte(pluginID))
+	return fmt.Sprintf("go-%x", hash[:4])
+}

--- a/runtime/ipc/convert.go
+++ b/runtime/ipc/convert.go
@@ -187,6 +187,11 @@ func decodeEvent(event *wire.Event) (*abi.Event, error) {
 	}, nil
 }
 
+// DecodeEvent converts an untrusted runtime wire event into the shared ABI form.
+func DecodeEvent(event *wire.Event) (*abi.Event, error) {
+	return decodeEvent(event)
+}
+
 func encodeHostCall(call abi.HostCall) (*wire.HostCall, error) {
 	fields, err := encodeValues(call.Fields)
 	if err != nil {
@@ -224,6 +229,11 @@ func encodeVerdict(verdict abi.Verdict) (*wire.Verdict, error) {
 		effects = append(effects, call)
 	}
 	return &wire.Verdict{Cancelled: verdict.Cancelled, Mutations: mutations, Effects: effects}, nil
+}
+
+// EncodeVerdict converts a plugin verdict for transmission to the host.
+func EncodeVerdict(verdict abi.Verdict) (*wire.Verdict, error) {
+	return encodeVerdict(verdict)
 }
 
 func decodeVerdict(verdict *wire.Verdict) (abi.Verdict, error) {

--- a/runtime/ipc/convert.go
+++ b/runtime/ipc/convert.go
@@ -167,6 +167,11 @@ func encodeEvent(event *abi.Event) (*wire.Event, error) {
 	}, nil
 }
 
+// EncodeEvent converts a shared event for transmission to a runtime.
+func EncodeEvent(event *abi.Event) (*wire.Event, error) {
+	return encodeEvent(event)
+}
+
 func decodeEvent(event *wire.Event) (*abi.Event, error) {
 	if event == nil {
 		return nil, fmt.Errorf("ipc: missing event")

--- a/server/plugins.go
+++ b/server/plugins.go
@@ -10,6 +10,7 @@ import (
 	"GoCraft/config"
 	"GoCraft/core/player"
 	coreplugin "GoCraft/core/plugin"
+	"GoCraft/runtime/goplugin"
 	"GoCraft/runtime/jvm"
 )
 
@@ -31,13 +32,19 @@ const pluginTickRate = 20
 // is why this runs unconditionally rather than behind a config switch.
 func (s *Server) registerPluginRuntimes(cfg *config.Config) error {
 	java := cfg.Plugins.Runtimes.JVM
-	return s.pluginRegistry.RegisterRuntime(jvm.New(jvm.Config{
+	if err := s.pluginRegistry.RegisterRuntime(jvm.New(jvm.Config{
 		JavaPath:     java.JavaPath,
 		PreferSystem: java.PreferSystem,
 		JarPath:      java.JarPath,
 		TickRate:     pluginTickRate,
 		EventBudget:  time.Duration(cfg.Plugins.EventBudgetMillis) * time.Millisecond,
 		OnRespawn:    s.replayJoins,
+	})); err != nil {
+		return err
+	}
+	return s.pluginRegistry.RegisterRuntime(goplugin.New(goplugin.Config{
+		TickRate:    pluginTickRate,
+		EventBudget: time.Duration(cfg.Plugins.EventBudgetMillis) * time.Millisecond,
 	}))
 }
 


### PR DESCRIPTION
## Summary

Adds the first experimental native Go plugin milestone alongside Traqueur's JVM runtime. Native plugins are compiled executables, one isolated process per plugin, and reuse the existing versioned IPC supervisor and shared plugin registry.

## Go runtime and API

- discovers runtime = go bundles through the existing .gcpkg scanner
- securely extracts the declared executable with path and size validation
- supports Linux, Windows, and macOS native executables through the existing AF_UNIX IPC transport
- implements OnLoad, OnEnable, and OnDisable with logger and per-plugin data directory access
- owns listeners, commands, and scheduled tasks and removes or cancels them on disable
- recovers listener, command, scheduler, and lifecycle panics with plugin identity and stack traces
- serializes gameplay callbacks per plugin while answering heartbeat pings independently
- supports typed PlayerJoinEvent and cancellable BlockBreakEvent
- routes both Java and Bedrock block breaks through the same existing canonical event and cancellation path
- supports host-validated typed command arguments and replies to player or console senders

## Example and documentation

- adds examples/go-plugin with lifecycle logging, join and block-break listeners, and /greet
- includes the generated commands.pb and reproducible generator
- documents build, packaging, plugins directory, data defaults, callback semantics, and limitations

## Tests

Added coverage for lifecycle success and failure, listener order and cleanup, cancellation, command ownership, panic recovery, scheduler cancellation, IPC heartbeat responsiveness, executable extraction, real child-process loading, event dispatch, commands, shutdown, and load or enable failure cleanup.

Verified:

- go test ./...
- go vet ./...
- go build ./...
- example executable and .gcpkg build through gocraft-cli

## Experimental limitations

- plugin binaries are OS and architecture specific
- hot reload is not supported
- failed native plugin processes are detected but not automatically respawned yet
- API v1 currently exposes PlayerJoinEvent and BlockBreakEvent only
- command invocation uses reserved ABI event and result names until dedicated protobuf envelope variants are designed

## Traqueur-owned code

No runtime/jvm or Java runtime files were changed. Shared changes are limited to backward-compatible IPC conversion wrappers, internal command call names, and server registration of the Go runtime. This PR targets feat/runtime-jvm so Traqueur can review the coexistence contract before any merge.