### PR TITLE
feat: :sparkles: issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,23 @@
+---
+name: 🐛 Bug Report
+about: Create a bug report
+title: "bug: "
+labels: ["status: unverified"]
+assignees: []
+---
+
+## 📝 Description
+
+Provide a clear, concise description of the unexpected behavior.
+
+## 🔍 Steps to reproduce
+
+Provide detailed instructions of how to reproduce
+
+## 💻 Environment
+
+- **Operating System / Distribution**:
+
+## 🛠️ Logs and additional context
+
+Paste your logs here

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 Read the wiki
+    url: https://github.com/GoCraft-MC/GoCraft/wiki
+    about: Read the wiki before reporting errors

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,9 @@
+---
+name: ✨ Feature
+about: Request new feature
+title: "feat: "
+labels: ["feature"]
+assignees: []
+---
+
+Describe your feature here


### PR DESCRIPTION
This PR adds GitHub issue templates for:

- features
- bugs

You probably want to fill them out or change them more - or add some more. I just used a generic set

# Changelog
ci: 🤖 add ISSUE_TEMPLATE/config.yaml
ci: 🤖 add ISSUE_TEMPLATE/bug.md
ci: 🤖 add ISSUE_TEMPLATE/feature.md